### PR TITLE
Add EPS build pipeline & automatic documentation publishing

### DIFF
--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -21,7 +21,7 @@ jobs:
         pip3 install -r eps/documentation/sphinx/requirements.txt
 
     - name: Configure CMake
-      run: cmake -B eps/firmware/build -S eps/firmware
+      run: cmake -B eps/firmware/build -S eps/firmware -DCMAKE_TOOLCHAIN_FILE=eps/firmware/arm-none-eabi-toolchain.cmake
 
     - name: Build firmware
       run: cmake --build eps/firmware/build

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -40,3 +40,30 @@ jobs:
       with:
         name: sphinx-documentation
         path: eps/firmware/build/documentation/sphinx/
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: eps/firmware/build/documentation/sphinx/
+        destination_dir: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '.' }}
+        keep_files: true
+
+    - name: Post Preview Link
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const prNumber = context.issue.number;
+          const repo = context.repo.repo;
+          const owner = context.repo.owner;
+
+          const pageUrl = `https://${owner}.github.io/${repo}/pr-${prNumber}/`;
+
+          github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: prNumber,
+            body: `**Documentation Preview:** [View Here](${pageUrl})`
+          });

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-arm-none-eabi doxygen python3-pip cmake
+        sudo apt-get install -y gcc-arm-none-eabi doxygen python3-pip cmake make
         pip3 install -r eps/documentation/sphinx/requirements.txt
 
     - name: Configure CMake
-      run: cmake -B eps/firmware/build -S eps/firmware -DCMAKE_TOOLCHAIN_FILE=eps/firmware/arm-none-eabi-toolchain.cmake
+      run: cmake -B eps/firmware/build -S eps/firmware -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/eps/firmware/arm-none-eabi-toolchain.cmake
 
     - name: Build firmware
       run: cmake --build eps/firmware/build

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-arm-none-eabi doxygen python3-pip cmake
-        pip3 install -r documentation/sphinx/requirements.txt
+        pip3 install -r eps/documentation/sphinx/requirements.txt
 
     - name: Configure CMake
       run: cmake -B eps/firmware/build -S firmware

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -1,4 +1,4 @@
-name: Build and Generate Documentation
+name: EPS Build and Generate Documentation
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
         pip3 install -r eps/documentation/sphinx/requirements.txt
 
     - name: Configure CMake
-      run: cmake -B eps/firmware/build -S firmware
+      run: cmake -B eps/firmware/build -S eps/firmware
 
     - name: Build firmware
       run: cmake --build eps/firmware/build
@@ -30,10 +30,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: doxygen-documentation
-        path: documentation/doxygen_output/
+        path: eps/documentation/doxygen_output/
 
     - name: Upload Sphinx documentation
       uses: actions/upload-artifact@v4
       with:
         name: sphinx-documentation
-        path: firmware/build/documentation/sphinx/
+        path: eps/firmware/build/documentation/sphinx/

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -26,14 +26,13 @@ jobs:
     - name: Generate documentation
       run: cmake --build eps/firmware/build --target docs
 
-    - name: Upload Doxygen documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doxygen-documentation
         path: documentation/doxygen_output/
 
     - name: Upload Sphinx documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sphinx-documentation
         path: firmware/build/documentation/sphinx/

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Generate documentation
       run: cmake --build eps/firmware/build --target docs
 
+    - name: Upload Doxygen documentation
       uses: actions/upload-artifact@v4
       with:
         name: doxygen-documentation

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build_and_docs.yml
+++ b/.github/workflows/build_and_docs.yml
@@ -1,0 +1,39 @@
+name: Build and Generate Documentation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi doxygen python3-pip cmake
+        pip3 install -r documentation/sphinx/requirements.txt
+
+    - name: Configure CMake
+      run: cmake -B eps/firmware/build -S firmware
+
+    - name: Build firmware
+      run: cmake --build eps/firmware/build
+
+    - name: Generate documentation
+      run: cmake --build eps/firmware/build --target docs
+
+    - name: Upload Doxygen documentation
+      uses: actions/upload-artifact@v3
+      with:
+        name: doxygen-documentation
+        path: documentation/doxygen_output/
+
+    - name: Upload Sphinx documentation
+      uses: actions/upload-artifact@v3
+      with:
+        name: sphinx-documentation
+        path: firmware/build/documentation/sphinx/

--- a/eps/documentation/sphinx/requirements.txt
+++ b/eps/documentation/sphinx/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+breathe

--- a/eps/firmware/CMakeLists.txt
+++ b/eps/firmware/CMakeLists.txt
@@ -81,6 +81,8 @@ if (DOXYGEN_FOUND)
             COMMENT "Generating Sphinx documentation"
             VERBATIM)
 
+        add_dependencies(sphinx doxygen)
+
         add_custom_target(docs
             DEPENDS doxygen sphinx)
     endif()


### PR DESCRIPTION
This PR introduces a new GitHub action with the following functionality:

- Build the EPS firmware using CMake
- Compile the documentation using Sphinx and Doxygen automatically
- Upload the documentation bundles as an artifact
- Automatically publish the documentation to GitHub pages
- Support documentation builds for staging environments. This allows a preview of documentation with new changes when reviewing PRs.