### PR TITLE
Add visual hardware diff pipeline

### DIFF
--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -11,6 +11,14 @@ on:
       - 'eps/hardware/**.kicad_sch'
       - 'eps/hardware/**.kicad_pcb'
       - 'eps/hardware/**.kicad_pro'
+      - '.github/workflows/hardware.yml'
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number to test (e.g. 15)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -45,5 +53,5 @@ jobs:
               owner,
               repo,
               issue_number: prNumber,
-              body: `⚡ **Hardware Interactive Diff:** [View Schematics & PCB](${pageUrl})`
+              body: `**Hardware Interactive Diff:** [View Schematics & PCB](${pageUrl})`
             });

--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -1,0 +1,49 @@
+name: EPS Hardware Visual Diff
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'eps/hardware/**.kicad_sch'
+      - 'eps/hardware/**.kicad_pcb'
+      - 'eps/hardware/**.kicad_pro'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  kiri-diff:
+    runs-on: ubuntu-latest
+    name: Kiri Schematic & PCB Diff
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Generate Interactive Diff
+        uses: usa-reddragon/kiri-github-action@v1
+        with:
+          project-file: 'eps/hardware/eps.kicad_pro'
+
+      - name: Post Diff Link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const repo = context.repo.repo;
+            const owner = context.repo.owner;
+            const pageUrl = `https://${owner}.github.io/${repo}/pr-${prNumber}/`;
+
+            github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: `⚡ **Hardware Interactive Diff:** [View Schematics & PCB](${pageUrl})`
+            });


### PR DESCRIPTION
This PR introduces a new GitHub action that automatically generates visual diffs for changes in KiCad projects.