### PR TITLE
add RBF inhibit pin & terminating load switch

### DIFF
--- a/eps/hardware/eps.kicad_sch
+++ b/eps/hardware/eps.kicad_sch
@@ -5,10 +5,10 @@
 	(uuid "9e0ae2e7-d4be-41b4-8312-0d2aceea2180")
 	(paper "A4")
 	(title_block
-		(title "SCRT Cubesat EPS")
+		(title "OSUSat CubeSat EPS")
 		(date "2025-08-22")
 		(rev "1")
-		(company "OSU")
+		(company "SCRT")
 	)
 	(lib_symbols
 		(symbol "Connector:USB_C_Receptacle_USB2.0_16P"
@@ -708,6 +708,148 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "Connector_Generic:Conn_01x02"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x02"
+				(at 0 -5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x02_1_1"
+				(rectangle
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:FerriteBead_Small"
 			(pin_numbers
 				(hide yes)
@@ -987,6 +1129,213 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Power_Management:TPS22810DRV"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at -6.35 6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TPS22810DRV"
+				(at 7.62 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_SON:WSON-6-1EP_2x2mm_P0.65mm_EP1x1.6mm"
+				(at 0 -17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tps22810.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "2.7..18V, 3A, 79mohms On-Resistance Load Switch With Thermal Protection, WSON-6"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "load switch thermal protection QOD quick-output-discharge"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "WSON*1EP*2x2mm*P0.65mm*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TPS22810DRV_1_1"
+				(rectangle
+					(start -7.62 5.08)
+					(end 7.62 -5.08)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin power_in line
+					(at -10.16 2.54 0)
+					(length 2.54)
+					(name "VIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 0 0)
+					(length 2.54)
+					(name "EN/UVLO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 10.16 2.54 180)
+					(length 2.54)
+					(name "VOUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin open_collector line
+					(at 10.16 0 180)
+					(length 2.54)
+					(name "QOD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 10.16 -2.54 180)
+					(length 2.54)
+					(name "CT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1576,8 +1925,8 @@
 		)
 	)
 	(rectangle
-		(start 229.87 92.71)
-		(end 283.21 154.94)
+		(start 199.136 92.71)
+		(end 236.474 152.4)
 		(stroke
 			(width 0)
 			(type dash)
@@ -1586,6 +1935,18 @@
 			(type none)
 		)
 		(uuid 62ba7a78-8faa-4740-9b3c-68c6a8cc2660)
+	)
+	(rectangle
+		(start 237.744 92.71)
+		(end 283.464 132.842)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 74ec0477-5065-4ffa-a3cf-0ab5d08f15dd)
 	)
 	(rectangle
 		(start 13.97 15.24)
@@ -1621,9 +1982,19 @@
 		)
 		(uuid "3b7e0bc1-086b-4f5f-926f-dedef227111d")
 	)
+	(text "Remove Before Flight Pin Inhibit"
+		(exclude_from_sim no)
+		(at 253.238 91.948 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "55d44c4d-82d9-4329-95c7-f1aa78dac1e0")
+	)
 	(text "USB/MPPT Power Selection Diode"
 		(exclude_from_sim no)
-		(at 245.618 91.948 0)
+		(at 215.138 91.948 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -1700,6 +2071,12 @@
 		(uuid "7b78af18-8e2f-4253-a87a-111ef407f561")
 	)
 	(junction
+		(at 238.76 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7eca62f3-1e15-4f2d-b0f2-7f5f5255dbde")
+	)
+	(junction
 		(at 55.88 30.48)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1736,6 +2113,12 @@
 		(uuid "c40aed9c-f2a1-4324-ac37-e784b1a74cf6")
 	)
 	(junction
+		(at 276.86 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d2566061-ab8e-48ab-b4b7-4b276ce4abcf")
+	)
+	(junction
 		(at 231.14 22.86)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -1746,6 +2129,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f23bcef5-8873-455a-a829-f20fe4f58572")
+	)
+	(junction
+		(at 246.38 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f36942d4-5720-4fee-aeec-ae2fef4954ee")
 	)
 	(no_connect
 		(at 49.53 58.42)
@@ -1759,9 +2148,13 @@
 		(at 157.48 25.4)
 		(uuid "5b7fbe10-50d7-4bc7-abb5-51f212e92355")
 	)
+	(no_connect
+		(at 266.7 107.95)
+		(uuid "e2b0eb8e-2cea-4100-9788-bfe1a9a93160")
+	)
 	(wire
 		(pts
-			(xy 241.3 130.81) (xy 245.11 130.81)
+			(xy 210.82 132.08) (xy 214.63 132.08)
 		)
 		(stroke
 			(width 0)
@@ -1831,6 +2224,16 @@
 	)
 	(wire
 		(pts
+			(xy 274.32 105.41) (xy 276.86 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "131d6135-0f12-4cf5-9d78-38387a00244b")
+	)
+	(wire
+		(pts
 			(xy 77.47 153.67) (xy 105.41 153.67)
 		)
 		(stroke
@@ -1841,7 +2244,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 120.65) (xy 245.11 120.65)
+			(xy 210.82 121.92) (xy 214.63 121.92)
 		)
 		(stroke
 			(width 0)
@@ -1858,6 +2261,16 @@
 			(type default)
 		)
 		(uuid "1b101717-335f-4af5-ae35-2d50c6fafe5f")
+	)
+	(wire
+		(pts
+			(xy 240.03 105.41) (xy 238.76 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c11c951-62f4-4e30-a55c-cd6b6906e7a4")
 	)
 	(wire
 		(pts
@@ -1911,6 +2324,16 @@
 	)
 	(wire
 		(pts
+			(xy 238.76 105.41) (xy 238.76 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29e17b69-92c8-40df-bc8b-ae359e3c3f50")
+	)
+	(wire
+		(pts
 			(xy 83.82 57.15) (xy 87.63 57.15)
 		)
 		(stroke
@@ -1938,6 +2361,16 @@
 			(type default)
 		)
 		(uuid "2f5e58cc-8098-4d2f-890c-c933a4e6b2e3")
+	)
+	(wire
+		(pts
+			(xy 276.86 105.41) (xy 276.86 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3110a8ae-55c5-445b-8026-5d2fac8c391c")
 	)
 	(wire
 		(pts
@@ -2051,7 +2484,7 @@
 	)
 	(wire
 		(pts
-			(xy 233.68 100.33) (xy 233.68 101.6)
+			(xy 203.2 101.6) (xy 203.2 102.87)
 		)
 		(stroke
 			(width 0)
@@ -2091,6 +2524,16 @@
 	)
 	(wire
 		(pts
+			(xy 248.92 119.38) (xy 254 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46ecc344-9425-4db3-833e-28130c5c8f33")
+	)
+	(wire
+		(pts
 			(xy 83.82 22.86) (xy 83.82 34.29)
 		)
 		(stroke
@@ -2098,6 +2541,16 @@
 			(type default)
 		)
 		(uuid "47a6efb0-f5c7-4724-ab36-e1cf151d3867")
+	)
+	(wire
+		(pts
+			(xy 238.76 102.87) (xy 246.38 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "47df2166-516c-4d85-a125-f7c2e5446548")
 	)
 	(wire
 		(pts
@@ -2131,7 +2584,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 123.19) (xy 245.11 123.19)
+			(xy 210.82 124.46) (xy 214.63 124.46)
 		)
 		(stroke
 			(width 0)
@@ -2351,7 +2804,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 115.57) (xy 245.11 115.57)
+			(xy 210.82 116.84) (xy 214.63 116.84)
 		)
 		(stroke
 			(width 0)
@@ -2361,7 +2814,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 128.27) (xy 245.11 128.27)
+			(xy 210.82 129.54) (xy 214.63 129.54)
 		)
 		(stroke
 			(width 0)
@@ -2371,7 +2824,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 135.89) (xy 245.11 135.89)
+			(xy 210.82 137.16) (xy 214.63 137.16)
 		)
 		(stroke
 			(width 0)
@@ -2451,7 +2904,7 @@
 	)
 	(wire
 		(pts
-			(xy 261.62 101.6) (xy 270.51 101.6)
+			(xy 231.14 102.87) (xy 238.76 102.87)
 		)
 		(stroke
 			(width 0)
@@ -2481,7 +2934,7 @@
 	)
 	(wire
 		(pts
-			(xy 233.68 142.24) (xy 233.68 147.32)
+			(xy 203.2 143.51) (xy 203.2 146.05)
 		)
 		(stroke
 			(width 0)
@@ -2601,6 +3054,16 @@
 	)
 	(wire
 		(pts
+			(xy 276.86 102.87) (xy 283.21 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a101e6b0-b41c-43e4-b986-1bab77925e07")
+	)
+	(wire
+		(pts
 			(xy 83.82 45.72) (xy 87.63 45.72)
 		)
 		(stroke
@@ -2701,7 +3164,7 @@
 	)
 	(wire
 		(pts
-			(xy 233.68 139.7) (xy 245.11 139.7)
+			(xy 203.2 140.97) (xy 214.63 140.97)
 		)
 		(stroke
 			(width 0)
@@ -2718,6 +3181,16 @@
 			(type default)
 		)
 		(uuid "aded5788-bde5-4de4-b046-c167f731fcb0")
+	)
+	(wire
+		(pts
+			(xy 266.7 105.41) (xy 269.24 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2e18752-f408-40ca-80c6-dd3c045b067f")
 	)
 	(wire
 		(pts
@@ -2781,7 +3254,7 @@
 	)
 	(wire
 		(pts
-			(xy 233.68 101.6) (xy 245.11 101.6)
+			(xy 203.2 102.87) (xy 214.63 102.87)
 		)
 		(stroke
 			(width 0)
@@ -2841,7 +3314,7 @@
 	)
 	(wire
 		(pts
-			(xy 245.11 142.24) (xy 233.68 142.24)
+			(xy 214.63 143.51) (xy 203.2 143.51)
 		)
 		(stroke
 			(width 0)
@@ -2911,6 +3384,16 @@
 	)
 	(wire
 		(pts
+			(xy 245.11 105.41) (xy 246.38 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb4ab13b-4aed-422f-95fe-387a786def92")
+	)
+	(wire
+		(pts
 			(xy 238.76 68.58) (xy 238.76 71.12)
 		)
 		(stroke
@@ -2928,6 +3411,26 @@
 			(type default)
 		)
 		(uuid "cd8d8330-ed9f-413e-b4af-2709421ba289")
+	)
+	(wire
+		(pts
+			(xy 246.38 105.41) (xy 246.38 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ced945d7-6dda-4f27-a683-256b4406d282")
+	)
+	(wire
+		(pts
+			(xy 248.92 119.38) (xy 248.92 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d157902b-e9b4-4fc0-8f84-f5e5f10d2dd9")
 	)
 	(wire
 		(pts
@@ -2961,6 +3464,16 @@
 	)
 	(wire
 		(pts
+			(xy 266.7 102.87) (xy 276.86 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6a9a33b-0dc5-4cef-9e08-26b820f805d1")
+	)
+	(wire
+		(pts
 			(xy 228.6 22.86) (xy 228.6 20.32)
 		)
 		(stroke
@@ -2988,6 +3501,16 @@
 			(type default)
 		)
 		(uuid "de16b9d5-798c-47b5-99a9-c6485aea9383")
+	)
+	(wire
+		(pts
+			(xy 254 119.38) (xy 254 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de4fb7be-75ef-478f-bd23-b4337045acb7")
 	)
 	(wire
 		(pts
@@ -3161,6 +3684,16 @@
 	)
 	(wire
 		(pts
+			(xy 256.54 113.03) (xy 256.54 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f697989a-ae92-4a1e-b25b-59b50c1c92f7")
+	)
+	(wire
+		(pts
 			(xy 143.51 104.14) (xy 149.86 104.14)
 		)
 		(stroke
@@ -3259,6 +3792,16 @@
 		)
 		(uuid "360f7ae9-a1b0-4d37-b050-74b7c593b9ec")
 	)
+	(label "VSYS"
+		(at 283.21 102.87 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "421cee74-6d7f-4b88-b111-8830d050a865")
+	)
 	(label "REG_1_SDA"
 		(at 274.32 66.04 180)
 		(effects
@@ -3329,18 +3872,8 @@
 		)
 		(uuid "81727315-41c7-4c4a-a6e2-37dd28ea10b7")
 	)
-	(label "VSYS"
-		(at 270.51 101.6 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "9a258a8d-c345-44be-bf8f-586abfed5fe8")
-	)
 	(label "MPPT_V"
-		(at 233.68 139.7 0)
+		(at 203.2 140.97 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3461,7 +3994,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 233.68 147.32 0)
+		(at 203.2 146.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -3470,7 +4003,7 @@
 		(fields_autoplaced yes)
 		(uuid "111aa015-6374-4557-8923-d259a7d4d6c9")
 		(property "Reference" "#PWR032"
-			(at 233.68 153.67 0)
+			(at 203.2 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3479,15 +4012,16 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 233.68 152.4 0)
+			(at 203.2 151.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(hide yes)
 			)
 		)
 		(property "Footprint" ""
-			(at 233.68 147.32 0)
+			(at 203.2 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3496,7 +4030,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 233.68 147.32 0)
+			(at 203.2 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3505,7 +4039,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 233.68 147.32 0)
+			(at 203.2 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3520,6 +4054,73 @@
 			(project ""
 				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
 					(reference "#PWR032")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small_US")
+		(at 271.78 105.41 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp yes)
+		(uuid "14e9a4fb-4efc-4289-8f89-bc2a9d5e8881")
+		(property "Reference" "R16"
+			(at 267.716 104.14 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "0"
+			(at 274.828 104.14 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 271.78 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small US symbol"
+			(at 271.78 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "abe45f60-5bb4-40a1-bdbe-f0502cdc9ef2")
+		)
+		(pin "1"
+			(uuid "31b33684-55b5-4628-822e-e23e72ae1dd2")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "R16")
 					(unit 1)
 				)
 			)
@@ -4129,7 +4730,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 241.3 133.35 0)
+		(at 210.82 134.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4137,7 +4738,7 @@
 		(dnp no)
 		(uuid "50a026f3-365b-403d-8ee2-c11949f74162")
 		(property "Reference" "R132"
-			(at 240.03 132.08 0)
+			(at 209.55 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4146,7 +4747,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 240.03 134.62 0)
+			(at 209.55 135.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4155,7 +4756,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 241.3 133.35 0)
+			(at 210.82 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4164,7 +4765,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 241.3 133.35 0)
+			(at 210.82 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4173,7 +4774,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 241.3 133.35 0)
+			(at 210.82 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4532,7 +5133,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 241.3 118.11 0)
+		(at 210.82 119.38 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4540,7 +5141,7 @@
 		(dnp no)
 		(uuid "71badc7a-bf23-4fc1-a785-e688011ed1f3")
 		(property "Reference" "R130"
-			(at 240.03 116.84 0)
+			(at 209.55 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4549,7 +5150,7 @@
 			)
 		)
 		(property "Value" "365k"
-			(at 240.03 119.38 0)
+			(at 209.55 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4558,7 +5159,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 241.3 118.11 0)
+			(at 210.82 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4567,7 +5168,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 241.3 118.11 0)
+			(at 210.82 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4576,7 +5177,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 241.3 118.11 0)
+			(at 210.82 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4601,7 +5202,7 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 233.68 100.33 0)
+		(at 203.2 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4610,7 +5211,7 @@
 		(fields_autoplaced yes)
 		(uuid "76197db6-089b-41f9-977d-3a5073881a2b")
 		(property "Reference" "#PWR015"
-			(at 233.68 104.14 0)
+			(at 203.2 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4619,7 +5220,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 233.68 95.25 0)
+			(at 203.2 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4627,7 +5228,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 233.68 100.33 0)
+			(at 203.2 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4636,7 +5237,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 233.68 100.33 0)
+			(at 203.2 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4645,7 +5246,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 233.68 100.33 0)
+			(at 203.2 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4734,6 +5335,74 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
+		(at 242.57 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "77ddb264-b653-4882-bf4d-65a1b40c79cf")
+		(property "Reference" "R21"
+			(at 242.57 109.982 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 242.57 107.95 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 242.57 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 242.57 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small US symbol"
+			(at 242.57 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad6e9d5b-4cf8-4f6c-a742-4f3c2cf2d50b")
+		)
+		(pin "2"
+			(uuid "de7af1d1-6919-4a41-b698-35228a6c42f5")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "R21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small_US")
 		(at 266.7 55.88 0)
 		(mirror y)
 		(unit 1)
@@ -4797,6 +5466,73 @@
 			(project "eps"
 				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
 					(reference "R8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 254 125.73 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7f0b18dd-4207-4770-802a-f76d71974251")
+		(property "Reference" "#PWR035"
+			(at 254 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 254 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 254 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 254 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 254 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "89378ab6-b534-4328-b10c-8c7912c97b1c")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "#PWR035")
 					(unit 1)
 				)
 			)
@@ -5524,7 +6260,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 241.3 125.73 0)
+		(at 210.82 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5532,7 +6268,7 @@
 		(dnp no)
 		(uuid "acd589da-5f4d-4d1b-896a-26dc7d792933")
 		(property "Reference" "R131"
-			(at 240.03 124.46 0)
+			(at 209.55 125.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5541,7 +6277,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 240.03 127 0)
+			(at 209.55 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5550,7 +6286,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 241.3 125.73 0)
+			(at 210.82 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5559,7 +6295,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 241.3 125.73 0)
+			(at 210.82 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5568,7 +6304,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 241.3 125.73 0)
+			(at 210.82 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5653,6 +6389,141 @@
 			(project ""
 				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
 					(reference "R109")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x02")
+		(at 246.38 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b5f7cb51-0fc6-4826-bdf1-52f41134c412")
+		(property "Reference" "J9"
+			(at 247.396 128.524 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Conn_01x02"
+			(at 247.396 130.556 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 246.38 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 246.38 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "310d9224-7a77-4bcd-a973-e27e83fcbe74")
+		)
+		(pin "2"
+			(uuid "4aeee6b1-9cf1-4d69-896c-d65ac9798717")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "J9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 256.54 116.84 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b62cdd03-fabd-46cf-ae07-aa856573a2a5")
+		(property "Reference" "#PWR034"
+			(at 256.54 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 256.54 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 256.54 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 256.54 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 256.54 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c64f4809-d0f3-40df-a9da-3d4890b2633d")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "#PWR034")
 					(unit 1)
 				)
 			)
@@ -6059,6 +6930,89 @@
 			(project ""
 				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
 					(reference "R118")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Power_Management:TPS22810DRV")
+		(at 256.54 105.41 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fe899854-f39d-4e46-ac67-a0accbf90aa6")
+		(property "Reference" "U42"
+			(at 256.54 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TPS22810DRV"
+			(at 256.54 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_SON:WSON-6-1EP_2x2mm_P0.65mm_EP1x1.6mm"
+			(at 256.54 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tps22810.pdf"
+			(at 256.54 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "2.7..18V, 3A, 79mohms On-Resistance Load Switch With Thermal Protection, WSON-6"
+			(at 256.54 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "6b978636-4d7a-404d-94ed-a1ffc32e8567")
+		)
+		(pin "6"
+			(uuid "03ed1c81-270a-4572-ac83-f52e05d6e2dc")
+		)
+		(pin "5"
+			(uuid "52a9bebd-8003-4de9-9973-1404bf737011")
+		)
+		(pin "1"
+			(uuid "49edc64c-da85-42b4-8fa2-a1e6fec20531")
+		)
+		(pin "7"
+			(uuid "d3496863-4f6f-428f-a2ee-306f7ab68c38")
+		)
+		(pin "4"
+			(uuid "4efc3d83-ebf2-4685-b09b-bc9716c4c881")
+		)
+		(pin "3"
+			(uuid "61064b49-957e-4ed5-94ff-c06d1e9a5669")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "U42")
 					(unit 1)
 				)
 			)
@@ -7629,7 +8583,7 @@
 		)
 	)
 	(sheet
-		(at 245.11 100.33)
+		(at 214.63 101.6)
 		(size 16.51 44.45)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7644,7 +8598,7 @@
 		)
 		(uuid "ea4c86fa-6561-475a-a54d-b57bbe53e74a")
 		(property "Sheetname" "Power Path Ideal Diode1"
-			(at 241.808 99.568 0)
+			(at 211.328 100.838 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7653,7 +8607,7 @@
 			)
 		)
 		(property "Sheetfile" "power_path_ideal_diode.kicad_sch"
-			(at 245.11 145.796 0)
+			(at 199.136 152.908 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7662,7 +8616,7 @@
 			)
 		)
 		(pin "3V3" input
-			(at 261.62 142.24 0)
+			(at 231.14 143.51 0)
 			(uuid "4dea1472-5153-4fef-803b-cbb7686feb82")
 			(effects
 				(font
@@ -7672,7 +8626,7 @@
 			)
 		)
 		(pin "GND" input
-			(at 245.11 142.24 180)
+			(at 214.63 143.51 180)
 			(uuid "bf36f1b7-43f4-4ebe-8a50-3eb9884f52e0")
 			(effects
 				(font
@@ -7682,7 +8636,7 @@
 			)
 		)
 		(pin "STAT1" output
-			(at 245.11 111.76 180)
+			(at 214.63 113.03 180)
 			(uuid "ff03d73b-a64b-45ca-9312-26a4ba797ea9")
 			(effects
 				(font
@@ -7692,7 +8646,7 @@
 			)
 		)
 		(pin "VIN1" input
-			(at 245.11 101.6 180)
+			(at 214.63 102.87 180)
 			(uuid "67e82985-542d-4d2a-8fa2-0e1d53ab2eb1")
 			(effects
 				(font
@@ -7702,7 +8656,7 @@
 			)
 		)
 		(pin "VOUT" input
-			(at 261.62 101.6 0)
+			(at 231.14 102.87 0)
 			(uuid "48ef5a02-c326-4287-8d31-12bf20c04af7")
 			(effects
 				(font
@@ -7712,7 +8666,7 @@
 			)
 		)
 		(pin "STAT2" output
-			(at 245.11 109.22 180)
+			(at 214.63 110.49 180)
 			(uuid "1437c587-ed62-4956-8e3b-ef4a6f94cdc1")
 			(effects
 				(font
@@ -7722,7 +8676,7 @@
 			)
 		)
 		(pin "WARN1" output
-			(at 245.11 106.68 180)
+			(at 214.63 107.95 180)
 			(uuid "b733227f-ece5-4d37-ae95-f3936a53becd")
 			(effects
 				(font
@@ -7732,7 +8686,7 @@
 			)
 		)
 		(pin "WARN2" output
-			(at 245.11 104.14 180)
+			(at 214.63 105.41 180)
 			(uuid "2794cf9a-a5f5-4a22-b272-63dfa229f637")
 			(effects
 				(font
@@ -7742,7 +8696,7 @@
 			)
 		)
 		(pin "VIN2" input
-			(at 245.11 139.7 180)
+			(at 214.63 140.97 180)
 			(uuid "283ca7c6-d75b-4bc7-8627-64540d3d36c1")
 			(effects
 				(font
@@ -7752,7 +8706,7 @@
 			)
 		)
 		(pin "R1+" input
-			(at 245.11 115.57 180)
+			(at 214.63 116.84 180)
 			(uuid "598c43cc-6f07-414b-ad07-e0ff515131f0")
 			(effects
 				(font
@@ -7762,7 +8716,7 @@
 			)
 		)
 		(pin "R1-" input
-			(at 245.11 120.65 180)
+			(at 214.63 121.92 180)
 			(uuid "f0401196-69b1-412e-8457-515ba514c9cc")
 			(effects
 				(font
@@ -7772,7 +8726,7 @@
 			)
 		)
 		(pin "R2+" input
-			(at 245.11 123.19 180)
+			(at 214.63 124.46 180)
 			(uuid "06ff975f-1e49-4b64-b3a7-caae4dd5ee9b")
 			(effects
 				(font
@@ -7782,7 +8736,7 @@
 			)
 		)
 		(pin "R2-" input
-			(at 245.11 128.27 180)
+			(at 214.63 129.54 180)
 			(uuid "a11224c3-f528-4988-926d-90036ff7068e")
 			(effects
 				(font
@@ -7792,7 +8746,7 @@
 			)
 		)
 		(pin "R3+" input
-			(at 245.11 130.81 180)
+			(at 214.63 132.08 180)
 			(uuid "958bbc14-06fc-4638-b37d-5c1ea3fe6e19")
 			(effects
 				(font
@@ -7802,7 +8756,7 @@
 			)
 		)
 		(pin "R3-" input
-			(at 245.11 135.89 180)
+			(at 214.63 137.16 180)
 			(uuid "ec4d9f27-81e4-47ff-a08f-90b614a4039b")
 			(effects
 				(font

--- a/eps/hardware/fp-info-cache
+++ b/eps/hardware/fp-info-cache
@@ -1,1 +1,211 @@
+52858692138724
+Jumper
+Jumper_Harwin_S1621_P10.9mm
+Harwin SMD jumper link, 12.3x2.3mm, 1.8mm height, 10.9mm pad pitch, https://cdn.harwin.com/pdfs/S1621R.pdf
+SMD jumper link
 0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Bridged2Bar_Pad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 2 copper strips
+net tie solder jumper bridged
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Bridged2Bar_RoundedPad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 2 copper strips
+net tie solder jumper bridged
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Bridged_Pad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, bridged with 1 copper strip
+net tie solder jumper bridged
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 1 copper strip
+net tie solder jumper bridged
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Open_Pad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, open
+solder jumper open
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, open
+solder jumper open
+0
+2
+2
+Jumper
+SolderJumper-2_P1.3mm_Open_TrianglePad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm Triangular Pads, 0.3mm gap, open
+solder jumper open
+0
+2
+2
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 2 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar12_Pad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 2 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 2 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar12_RoundedPad1.0x1.5mm_NumberLabels
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 2 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar123_Pad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2-3 bridged with 2 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar123_Pad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2-3 bridged with 2 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar123_RoundedPad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2-3 bridged with 2 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged2Bar123_RoundedPad1.0x1.5mm_NumberLabels
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2-3 bridged with 2 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged12_Pad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged12_RoundedPad1.0x1.5mm_NumberLabels
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2 bridged with 1 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged123_Pad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2-3 bridged with 1 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged123_Pad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, pads 1-2-3 bridged with 1 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged123_RoundedPad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2-3 bridged with 1 copper strip
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Bridged123_RoundedPad1.0x1.5mm_NumberLabels
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, pads 1-2-3 bridged with 1 copper strip, labeled with numbers
+net tie solder jumper bridged
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Open_Pad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm Pads, 0.3mm gap, open
+solder jumper open
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Open_Pad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Pads, 0.3mm gap, open, labeled with numbers
+solder jumper open
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, open
+solder jumper open
+0
+3
+3
+Jumper
+SolderJumper-3_P1.3mm_Open_RoundedPad1.0x1.5mm_NumberLabels
+SMD Solder 3-pad Jumper, 1x1.5mm rounded Pads, 0.3mm gap, open, labeled with numbers
+solder jumper open
+0
+3
+3
+Jumper
+SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm
+SMD Solder Jumper, 1x1.5mm Triangular Pads, 0.3mm gap, open
+solder jumper open
+0
+3
+3
+Jumper
+SolderJumper-3_P2.0mm_Open_TrianglePad1.0x1.5mm_NumberLabels
+SMD Solder Jumper, 1x1.5mm Triangular Pads, 0.3mm gap, open, labeled with numbers
+solder jumper open
+0
+3
+3


### PR DESCRIPTION
These changes introduce the following:

- Adds a remove before flight (RBF) pin header for use with a jumper
    - According to the CDS, when the RBF jumper is **inserted**, the power must be cut from all downstream loads
- Adds a load switch between the input power path (MPPT/USB) and the downstream loads (battery charger -> regulators -> system rails)

## How it's implemented

- There is a 100k pull-up resistor between the enable pin on the load switch and the VIN line that enables the flow of electricity when the RBF pin is not inserted
- There is a 1x2 pin header where:
    - Pin 1 is connected to the EN pin
    - Pin 2 is connected to GND
- Thus, when the RBF pin is inserted, the enable pin is shorted to ground. Since EN is active high, inserting the RBF pin cuts the connection between the input and downstream loads.

**NOTE:** this is not the only required inhibit by the CDS for flight requirements. It's up to us to decide if we want to add deployment switch inhibits for this prototype flight or not.