### PR TITLE
finish stm32 pinout + inter-board connector

### DIFF
--- a/eps/hardware/eps.kicad_pro
+++ b/eps/hardware/eps.kicad_pro
@@ -718,6 +718,10 @@
     [
       "ea4c86fa-6561-475a-a54d-b57bbe53e74a",
       "Power Path Ideal Diode1"
+    ],
+    [
+      "b219b5f3-4d87-4e00-9626-11450f76e9f7",
+      "Inter-Board Connector"
     ]
   ],
   "text_variables": {}

--- a/eps/hardware/eps.kicad_sch
+++ b/eps/hardware/eps.kicad_sch
@@ -1925,6 +1925,30 @@
 		)
 	)
 	(rectangle
+		(start 95.25 95.25)
+		(end 149.86 194.31)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 41f325ff-66f1-4fca-9fd7-376956dcaf58)
+	)
+	(rectangle
+		(start 13.97 95.25)
+		(end 93.98 194.31)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 5d0cc140-9800-4728-91c2-c5eabdfbd91a)
+	)
+	(rectangle
 		(start 199.136 92.71)
 		(end 236.474 152.4)
 		(stroke
@@ -1935,6 +1959,18 @@
 			(type none)
 		)
 		(uuid 62ba7a78-8faa-4740-9b3c-68c6a8cc2660)
+	)
+	(rectangle
+		(start 237.744 136.144)
+		(end 276.86 160.782)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 71655e9d-2174-4572-96e9-1888f28cef2e)
 	)
 	(rectangle
 		(start 237.744 92.71)
@@ -1961,6 +1997,18 @@
 		(uuid a391fd39-28f7-47a9-85d2-34d7a20d6152)
 	)
 	(rectangle
+		(start 151.13 95.25)
+		(end 198.12 160.02)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid b3f7ea79-798a-4ff1-b606-1a9a46413fad)
+	)
+	(rectangle
 		(start 80.01 15.24)
 		(end 283.21 90.17)
 		(stroke
@@ -1982,6 +2030,16 @@
 		)
 		(uuid "3b7e0bc1-086b-4f5f-926f-dedef227111d")
 	)
+	(text "Inter-Board-Connector"
+		(exclude_from_sim no)
+		(at 162.052 94.488 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "419d1dc0-0e9b-4aa4-a8d9-4d367b6fff0e")
+	)
 	(text "Remove Before Flight Pin Inhibit"
 		(exclude_from_sim no)
 		(at 253.238 91.948 0)
@@ -1991,6 +2049,16 @@
 			)
 		)
 		(uuid "55d44c4d-82d9-4329-95c7-f1aa78dac1e0")
+	)
+	(text "Watchdog Timer"
+		(exclude_from_sim no)
+		(at 245.11 135.128 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "713cac3a-7632-4110-87c7-3fc33c9add3f")
 	)
 	(text "USB/MPPT Power Selection Diode"
 		(exclude_from_sim no)
@@ -2002,6 +2070,16 @@
 		)
 		(uuid "a77e6a83-e7a0-4d67-bbef-1ccbfa5557f4")
 	)
+	(text "Current Monitors"
+		(exclude_from_sim no)
+		(at 102.87 94.488 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "adad3d00-183d-4c2a-b358-b1e5adba5646")
+	)
 	(text "Power Domain"
 		(exclude_from_sim no)
 		(at 86.614 13.97 0)
@@ -2011,6 +2089,16 @@
 			)
 		)
 		(uuid "d8a2fee5-b6d6-4d33-91c0-1187f79da400")
+	)
+	(text "STM32L496ZGT"
+		(exclude_from_sim no)
+		(at 20.828 94.488 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "dd98e220-f364-4d0a-8ed9-10f34747604f")
 	)
 	(text "USB Aux Power Input"
 		(exclude_from_sim no)
@@ -2027,6 +2115,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "087b4a66-0c2b-436e-b80c-ef05b9ef7ffc")
+	)
+	(junction
+		(at 120.65 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "19d89fbb-45d1-4c84-96db-202567ece2f9")
 	)
 	(junction
 		(at 116.84 68.58)
@@ -2145,16 +2239,32 @@
 		(uuid "33bb12dd-5e3f-457b-b83e-dd528a3e07ce")
 	)
 	(no_connect
-		(at 157.48 25.4)
-		(uuid "5b7fbe10-50d7-4bc7-abb5-51f212e92355")
-	)
-	(no_connect
 		(at 266.7 107.95)
 		(uuid "e2b0eb8e-2cea-4100-9788-bfe1a9a93160")
 	)
 	(wire
 		(pts
-			(xy 210.82 132.08) (xy 214.63 132.08)
+			(xy 16.51 168.91) (xy 27.94 168.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06f5f2bc-f0e7-4334-8611-7f0bbd3245e9")
+	)
+	(wire
+		(pts
+			(xy 16.51 172.72) (xy 27.94 172.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b0e35b6-1671-49a3-9211-8945312f6b75")
+	)
+	(wire
+		(pts
+			(xy 209.55 132.08) (xy 213.36 132.08)
 		)
 		(stroke
 			(width 0)
@@ -2171,6 +2281,16 @@
 			(type default)
 		)
 		(uuid "0d4a3d19-e797-4e02-9d56-d68270eb9370")
+	)
+	(wire
+		(pts
+			(xy 16.51 186.69) (xy 27.94 186.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e41d0d7-ccbb-42ab-b13f-e0c0c404014c")
 	)
 	(wire
 		(pts
@@ -2204,6 +2324,16 @@
 	)
 	(wire
 		(pts
+			(xy 78.74 175.26) (xy 92.71 175.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11bb82af-6a0c-4aa0-8e42-52b2a4a1f52d")
+	)
+	(wire
+		(pts
 			(xy 261.62 68.58) (xy 274.32 68.58)
 		)
 		(stroke
@@ -2211,6 +2341,16 @@
 			(type default)
 		)
 		(uuid "11eda84a-2a44-493b-a18f-0583348d4bad")
+	)
+	(wire
+		(pts
+			(xy 143.51 134.62) (xy 152.4 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "122032b9-b5cc-4a8f-a106-bef53c1992ce")
 	)
 	(wire
 		(pts
@@ -2234,7 +2374,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 153.67) (xy 105.41 153.67)
+			(xy 78.74 153.67) (xy 105.41 153.67)
 		)
 		(stroke
 			(width 0)
@@ -2244,7 +2384,27 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 121.92) (xy 214.63 121.92)
+			(xy 78.74 166.37) (xy 92.71 166.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "149484c4-0ae7-4d94-b43c-a5d8fc6c6534")
+	)
+	(wire
+		(pts
+			(xy 16.51 184.15) (xy 27.94 184.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14af6a83-9d8e-452b-8d79-29e2cad42ab8")
+	)
+	(wire
+		(pts
+			(xy 209.55 121.92) (xy 213.36 121.92)
 		)
 		(stroke
 			(width 0)
@@ -2254,7 +2414,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 134.62) (xy 105.41 134.62)
+			(xy 78.74 134.62) (xy 105.41 134.62)
 		)
 		(stroke
 			(width 0)
@@ -2274,7 +2434,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 137.16) (xy 105.41 137.16)
+			(xy 78.74 137.16) (xy 105.41 137.16)
 		)
 		(stroke
 			(width 0)
@@ -2314,6 +2474,16 @@
 	)
 	(wire
 		(pts
+			(xy 78.74 184.15) (xy 92.71 184.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21776d17-b7f0-4b0e-9103-5efd7ead9d74")
+	)
+	(wire
+		(pts
 			(xy 83.82 34.29) (xy 87.63 34.29)
 		)
 		(stroke
@@ -2321,6 +2491,16 @@
 			(type default)
 		)
 		(uuid "22866da9-96f9-4027-bb81-da8bd74897f5")
+	)
+	(wire
+		(pts
+			(xy 143.51 153.67) (xy 152.4 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "242e8502-1da5-4fbe-91ef-6a6e63f1f22a")
 	)
 	(wire
 		(pts
@@ -2334,6 +2514,16 @@
 	)
 	(wire
 		(pts
+			(xy 167.64 46.99) (xy 177.8 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2aac6881-810d-4c3e-9c53-4e7c05e50621")
+	)
+	(wire
+		(pts
 			(xy 83.82 57.15) (xy 87.63 57.15)
 		)
 		(stroke
@@ -2341,6 +2531,16 @@
 			(type default)
 		)
 		(uuid "2e05bec8-1bd7-41b2-b5f8-0bd6c3b1bab4")
+	)
+	(wire
+		(pts
+			(xy 16.51 114.3) (xy 27.94 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e1daeef-d102-4af5-9857-3b74aa03686d")
 	)
 	(wire
 		(pts
@@ -2354,6 +2554,16 @@
 	)
 	(wire
 		(pts
+			(xy 187.96 111.76) (xy 196.85 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e66ee1b-fa1f-423f-aed0-75a876bd2f06")
+	)
+	(wire
+		(pts
 			(xy 83.82 68.58) (xy 87.63 68.58)
 		)
 		(stroke
@@ -2361,6 +2571,26 @@
 			(type default)
 		)
 		(uuid "2f5e58cc-8098-4d2f-890c-c933a4e6b2e3")
+	)
+	(wire
+		(pts
+			(xy 78.74 104.14) (xy 91.44 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2fc45411-947d-45d2-998e-d9af7bd06aec")
+	)
+	(wire
+		(pts
+			(xy 167.64 52.07) (xy 177.8 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ff4de13-32f1-4460-8aea-d25db786e2fe")
 	)
 	(wire
 		(pts
@@ -2414,6 +2644,16 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 154.94) (xy 27.94 154.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "39d77f44-13e2-41ab-b494-ede49987c4a5")
+	)
+	(wire
+		(pts
 			(xy 231.14 22.86) (xy 245.11 22.86)
 		)
 		(stroke
@@ -2434,7 +2674,7 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 109.22) (xy 26.67 109.22)
+			(xy 16.51 109.22) (xy 27.94 109.22)
 		)
 		(stroke
 			(width 0)
@@ -2444,7 +2684,17 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 97.79) (xy 149.86 104.14)
+			(xy 16.51 134.62) (xy 27.94 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cc6da8e-0c20-4df9-a0b5-b60c18e37062")
+	)
+	(wire
+		(pts
+			(xy 146.05 101.6) (xy 146.05 104.14)
 		)
 		(stroke
 			(width 0)
@@ -2474,6 +2724,16 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 118.11) (xy 27.94 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e479b10-99ca-4316-bde2-1004d35b1dd2")
+	)
+	(wire
+		(pts
 			(xy 83.82 80.01) (xy 83.82 86.36)
 		)
 		(stroke
@@ -2484,7 +2744,7 @@
 	)
 	(wire
 		(pts
-			(xy 203.2 101.6) (xy 203.2 102.87)
+			(xy 201.93 101.6) (xy 201.93 102.87)
 		)
 		(stroke
 			(width 0)
@@ -2494,7 +2754,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 115.57) (xy 105.41 115.57)
+			(xy 78.74 115.57) (xy 105.41 115.57)
 		)
 		(stroke
 			(width 0)
@@ -2521,6 +2781,16 @@
 			(type default)
 		)
 		(uuid "449be383-6f15-444d-a318-f015d322b112")
+	)
+	(wire
+		(pts
+			(xy 120.65 31.75) (xy 120.65 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45e44925-e001-4c1b-875d-122e922ee8b0")
 	)
 	(wire
 		(pts
@@ -2574,6 +2844,46 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 129.54) (xy 27.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4dc464ad-b11e-405c-a525-f2969f13e83e")
+	)
+	(wire
+		(pts
+			(xy 199.39 30.48) (xy 209.55 30.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e206050-8d09-4dc7-a602-88bfc78d7e4d")
+	)
+	(wire
+		(pts
+			(xy 187.96 118.11) (xy 196.85 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4fb3a410-8afb-4366-8c93-70faac34327f")
+	)
+	(wire
+		(pts
+			(xy 232.41 143.51) (xy 229.87 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5099b359-19cd-4024-b60a-1d2c11886a34")
+	)
+	(wire
+		(pts
 			(xy 207.01 49.53) (xy 209.55 49.53)
 		)
 		(stroke
@@ -2584,7 +2894,7 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 124.46) (xy 214.63 124.46)
+			(xy 209.55 124.46) (xy 213.36 124.46)
 		)
 		(stroke
 			(width 0)
@@ -2594,7 +2904,17 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 143.51) (xy 105.41 143.51)
+			(xy 16.51 148.59) (xy 27.94 148.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "531f2f51-a4e5-4054-b041-761caf0cfa06")
+	)
+	(wire
+		(pts
+			(xy 78.74 143.51) (xy 105.41 143.51)
 		)
 		(stroke
 			(width 0)
@@ -2614,7 +2934,17 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 109.22) (xy 105.41 109.22)
+			(xy 16.51 175.26) (xy 27.94 175.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "549b6ced-b282-4499-9c8e-b5077fc6b266")
+	)
+	(wire
+		(pts
+			(xy 78.74 109.22) (xy 105.41 109.22)
 		)
 		(stroke
 			(width 0)
@@ -2624,7 +2954,27 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 130.81) (xy 105.41 130.81)
+			(xy 167.64 49.53) (xy 177.8 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55cc418e-fea2-4bcc-8940-98e8571bc579")
+	)
+	(wire
+		(pts
+			(xy 167.64 27.94) (xy 177.8 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "566a97c5-89ea-4071-a203-330e2daeb5f3")
+	)
+	(wire
+		(pts
+			(xy 78.74 130.81) (xy 105.41 130.81)
 		)
 		(stroke
 			(width 0)
@@ -2644,7 +2994,17 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 111.76) (xy 105.41 111.76)
+			(xy 199.39 22.86) (xy 209.55 22.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ddff107-2e4f-4889-b542-dbc43a596a9d")
+	)
+	(wire
+		(pts
+			(xy 78.74 111.76) (xy 105.41 111.76)
 		)
 		(stroke
 			(width 0)
@@ -2654,7 +3014,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 187.96) (xy 148.59 187.96)
+			(xy 143.51 187.96) (xy 147.32 187.96)
 		)
 		(stroke
 			(width 0)
@@ -2684,7 +3044,27 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 104.14) (xy 26.67 104.14)
+			(xy 16.51 120.65) (xy 27.94 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6101bdf2-3402-48a3-8eaa-0c9b35f299f9")
+	)
+	(wire
+		(pts
+			(xy 16.51 152.4) (xy 27.94 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "622e4684-1c78-4980-ab44-7b5c102ed2e7")
+	)
+	(wire
+		(pts
+			(xy 19.05 104.14) (xy 27.94 104.14)
 		)
 		(stroke
 			(width 0)
@@ -2704,13 +3084,13 @@
 	)
 	(wire
 		(pts
-			(xy 92.71 97.79) (xy 92.71 106.68)
+			(xy 16.51 125.73) (xy 27.94 125.73)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "66079883-4209-45d1-8879-ac2e7793295e")
+		(uuid "65d42cc3-1435-4953-9ec8-3bb93cba1b29")
 	)
 	(wire
 		(pts
@@ -2724,7 +3104,7 @@
 	)
 	(wire
 		(pts
-			(xy 92.71 106.68) (xy 105.41 106.68)
+			(xy 100.33 106.68) (xy 105.41 106.68)
 		)
 		(stroke
 			(width 0)
@@ -2754,7 +3134,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 149.86) (xy 105.41 149.86)
+			(xy 78.74 149.86) (xy 105.41 149.86)
 		)
 		(stroke
 			(width 0)
@@ -2774,6 +3154,26 @@
 	)
 	(wire
 		(pts
+			(xy 232.41 140.97) (xy 232.41 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6bd84b9c-03e4-42f3-a87c-ab3418fe8776")
+	)
+	(wire
+		(pts
+			(xy 16.51 181.61) (xy 27.94 181.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c284459-2bf1-42e5-9c6f-d20f2e147782")
+	)
+	(wire
+		(pts
 			(xy 241.3 53.34) (xy 245.11 53.34)
 		)
 		(stroke
@@ -2781,6 +3181,16 @@
 			(type default)
 		)
 		(uuid "6cc261e3-4824-43d5-a62d-b157f35a4e3a")
+	)
+	(wire
+		(pts
+			(xy 78.74 168.91) (xy 92.71 168.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f6592e8-a67c-4d79-8c7c-f76ac9247f97")
 	)
 	(wire
 		(pts
@@ -2804,7 +3214,17 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 116.84) (xy 214.63 116.84)
+			(xy 16.51 140.97) (xy 27.94 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6feb33ea-1c26-4269-a6d2-14ec8fa1cbd6")
+	)
+	(wire
+		(pts
+			(xy 209.55 116.84) (xy 213.36 116.84)
 		)
 		(stroke
 			(width 0)
@@ -2814,7 +3234,7 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 129.54) (xy 214.63 129.54)
+			(xy 209.55 129.54) (xy 213.36 129.54)
 		)
 		(stroke
 			(width 0)
@@ -2824,13 +3244,23 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 137.16) (xy 214.63 137.16)
+			(xy 209.55 137.16) (xy 213.36 137.16)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "7431a595-ad1b-4445-a837-7824d3f491d3")
+	)
+	(wire
+		(pts
+			(xy 78.74 186.69) (xy 92.71 186.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "745cfed0-82dc-47fc-a01c-490794956a65")
 	)
 	(wire
 		(pts
@@ -2844,7 +3274,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 20.32) (xy 167.64 41.91)
+			(xy 166.37 20.32) (xy 166.37 41.91)
 		)
 		(stroke
 			(width 0)
@@ -2894,7 +3324,17 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 156.21) (xy 105.41 156.21)
+			(xy 16.51 137.16) (xy 27.94 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f225e11-777e-4035-9dc6-f107a9d69399")
+	)
+	(wire
+		(pts
+			(xy 78.74 156.21) (xy 105.41 156.21)
 		)
 		(stroke
 			(width 0)
@@ -2904,13 +3344,33 @@
 	)
 	(wire
 		(pts
-			(xy 231.14 102.87) (xy 238.76 102.87)
+			(xy 229.87 102.87) (xy 238.76 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "80a716e7-6d6b-4e0c-bd08-bb7a7765ec65")
+	)
+	(wire
+		(pts
+			(xy 143.51 109.22) (xy 152.4 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "813ff633-b658-47c8-98ae-c691c4f69686")
+	)
+	(wire
+		(pts
+			(xy 241.3 143.51) (xy 246.38 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8292ffe5-78a1-43bb-8830-f9f9bbb51cd1")
 	)
 	(wire
 		(pts
@@ -2924,7 +3384,17 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 124.46) (xy 105.41 124.46)
+			(xy 265.43 154.94) (xy 275.59 154.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "871859f4-3fea-4eaa-9339-2a2c0f4317af")
+	)
+	(wire
+		(pts
+			(xy 78.74 124.46) (xy 105.41 124.46)
 		)
 		(stroke
 			(width 0)
@@ -2934,7 +3404,7 @@
 	)
 	(wire
 		(pts
-			(xy 203.2 143.51) (xy 203.2 146.05)
+			(xy 201.93 143.51) (xy 201.93 146.05)
 		)
 		(stroke
 			(width 0)
@@ -2964,6 +3434,16 @@
 	)
 	(wire
 		(pts
+			(xy 229.87 60.96) (xy 226.06 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd061cd-9748-44c5-882f-ebe5f25b4e83")
+	)
+	(wire
+		(pts
 			(xy 228.6 20.32) (xy 226.06 20.32)
 		)
 		(stroke
@@ -2971,6 +3451,16 @@
 			(type default)
 		)
 		(uuid "8ebf8e74-37a9-4ac6-a33d-794516336a8d")
+	)
+	(wire
+		(pts
+			(xy 265.43 147.32) (xy 275.59 147.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f07c7d9-a743-444c-9288-abafba9469d7")
 	)
 	(wire
 		(pts
@@ -2984,7 +3474,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 104.14) (xy 105.41 104.14)
+			(xy 100.33 104.14) (xy 105.41 104.14)
 		)
 		(stroke
 			(width 0)
@@ -2994,7 +3484,7 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 41.91) (xy 177.8 41.91)
+			(xy 166.37 41.91) (xy 177.8 41.91)
 		)
 		(stroke
 			(width 0)
@@ -3004,13 +3494,43 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 128.27) (xy 105.41 128.27)
+			(xy 167.64 30.48) (xy 177.8 30.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9218e811-a283-43fa-9ac7-cdb1a9146cb6")
+	)
+	(wire
+		(pts
+			(xy 78.74 128.27) (xy 105.41 128.27)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "9314b508-730f-4ec8-a1f3-0812bdcddb31")
+	)
+	(wire
+		(pts
+			(xy 167.64 25.4) (xy 177.8 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93a48eb8-99de-4bdd-b905-cc70ffc43233")
+	)
+	(wire
+		(pts
+			(xy 265.43 151.13) (xy 275.59 151.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "947c8853-b46a-4b50-b21e-b7d3787e872e")
 	)
 	(wire
 		(pts
@@ -3024,16 +3544,6 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 97.79) (xy 99.06 104.14)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "988ad559-1d91-494c-b5c7-968ce64cd4ba")
-	)
-	(wire
-		(pts
 			(xy 116.84 45.72) (xy 116.84 34.29)
 		)
 		(stroke
@@ -3044,6 +3554,26 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 123.19) (xy 27.94 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b70a011-16fb-403f-aaf6-462bcd676405")
+	)
+	(wire
+		(pts
+			(xy 229.87 57.15) (xy 229.87 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ea5772a-ce28-4128-aafe-ce6f151dfcc3")
+	)
+	(wire
+		(pts
 			(xy 63.5 35.56) (xy 72.39 35.56)
 		)
 		(stroke
@@ -3051,6 +3581,16 @@
 			(type default)
 		)
 		(uuid "9f1ed67b-c722-46cd-8234-411e563068ae")
+	)
+	(wire
+		(pts
+			(xy 167.64 44.45) (xy 177.8 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9feedd23-bf41-418b-9fa7-2727c77197d7")
 	)
 	(wire
 		(pts
@@ -3094,7 +3634,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 140.97) (xy 105.41 140.97)
+			(xy 78.74 140.97) (xy 105.41 140.97)
 		)
 		(stroke
 			(width 0)
@@ -3111,6 +3651,16 @@
 			(type default)
 		)
 		(uuid "a6f517c8-504d-418d-a0d5-c3770a3fa432")
+	)
+	(wire
+		(pts
+			(xy 143.51 128.27) (xy 152.4 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a71dc17b-ce53-441a-bb2f-2bcf457c85e2")
 	)
 	(wire
 		(pts
@@ -3134,7 +3684,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 121.92) (xy 105.41 121.92)
+			(xy 78.74 121.92) (xy 105.41 121.92)
 		)
 		(stroke
 			(width 0)
@@ -3154,6 +3704,16 @@
 	)
 	(wire
 		(pts
+			(xy 167.64 22.86) (xy 177.8 22.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab342909-c915-4a39-8c7a-c8a08ab63ff9")
+	)
+	(wire
+		(pts
 			(xy 241.3 25.4) (xy 245.11 25.4)
 		)
 		(stroke
@@ -3164,7 +3724,27 @@
 	)
 	(wire
 		(pts
-			(xy 203.2 140.97) (xy 214.63 140.97)
+			(xy 201.93 105.41) (xy 213.36 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ac594008-8a35-49d6-bb0e-6b7f86e4ef5e")
+	)
+	(wire
+		(pts
+			(xy 187.96 143.51) (xy 196.85 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad49088f-be72-41a0-8f1c-93ab962c1005")
+	)
+	(wire
+		(pts
+			(xy 201.93 140.97) (xy 213.36 140.97)
 		)
 		(stroke
 			(width 0)
@@ -3181,6 +3761,36 @@
 			(type default)
 		)
 		(uuid "aded5788-bde5-4de4-b046-c167f731fcb0")
+	)
+	(wire
+		(pts
+			(xy 16.51 177.8) (xy 27.94 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b16d225f-e03c-4da4-9ea2-492a52988025")
+	)
+	(wire
+		(pts
+			(xy 199.39 27.94) (xy 209.55 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b19f7735-785c-4395-a769-4655b1545026")
+	)
+	(wire
+		(pts
+			(xy 16.51 143.51) (xy 27.94 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b21a5fa4-4ee2-4c89-82fa-b316486ac7f3")
 	)
 	(wire
 		(pts
@@ -3201,6 +3811,16 @@
 			(type default)
 		)
 		(uuid "b46ce17b-ee9f-4915-b860-fcd030bc712f")
+	)
+	(wire
+		(pts
+			(xy 241.3 142.24) (xy 241.3 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b4a642aa-aa00-46d1-8be4-60ae1ea802f6")
 	)
 	(wire
 		(pts
@@ -3244,7 +3864,7 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 101.6) (xy 15.24 104.14)
+			(xy 19.05 101.6) (xy 19.05 104.14)
 		)
 		(stroke
 			(width 0)
@@ -3254,7 +3874,17 @@
 	)
 	(wire
 		(pts
-			(xy 203.2 102.87) (xy 214.63 102.87)
+			(xy 143.51 121.92) (xy 152.4 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9d9dadf-4177-43fc-bddb-0d1b2fc495d7")
+	)
+	(wire
+		(pts
+			(xy 201.93 102.87) (xy 213.36 102.87)
 		)
 		(stroke
 			(width 0)
@@ -3271,6 +3901,16 @@
 			(type default)
 		)
 		(uuid "baa1bcdf-d686-445f-9367-11ee041d5214")
+	)
+	(wire
+		(pts
+			(xy 16.51 163.83) (xy 27.94 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb6e0424-2e73-4845-bbba-0e2fd86fb22c")
 	)
 	(wire
 		(pts
@@ -3294,7 +3934,17 @@
 	)
 	(wire
 		(pts
-			(xy 167.64 20.32) (xy 177.8 20.32)
+			(xy 201.93 113.03) (xy 213.36 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf376a85-b224-44aa-b4fc-00fa074f3cc5")
+	)
+	(wire
+		(pts
+			(xy 166.37 20.32) (xy 177.8 20.32)
 		)
 		(stroke
 			(width 0)
@@ -3314,7 +3964,7 @@
 	)
 	(wire
 		(pts
-			(xy 214.63 143.51) (xy 203.2 143.51)
+			(xy 213.36 143.51) (xy 201.93 143.51)
 		)
 		(stroke
 			(width 0)
@@ -3331,6 +3981,26 @@
 			(type default)
 		)
 		(uuid "c3472bc9-9bf2-4f3c-86a3-25ab914e0040")
+	)
+	(wire
+		(pts
+			(xy 187.96 130.81) (xy 196.85 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3d0b5dd-984f-4993-bb70-d429a89fba79")
+	)
+	(wire
+		(pts
+			(xy 143.51 147.32) (xy 152.4 147.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4be95f6-9471-47ff-a5ff-9b75c53d72cc")
 	)
 	(wire
 		(pts
@@ -3364,13 +4034,23 @@
 	)
 	(wire
 		(pts
-			(xy 181.61 143.51) (xy 191.77 143.51)
+			(xy 265.43 143.51) (xy 275.59 143.51)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "c9d47282-401d-4607-a065-3dae0c7fa971")
+	)
+	(wire
+		(pts
+			(xy 187.96 137.16) (xy 196.85 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca411fde-0b07-4f44-ac74-7d10f0c45f64")
 	)
 	(wire
 		(pts
@@ -3404,13 +4084,23 @@
 	)
 	(wire
 		(pts
-			(xy 120.65 30.48) (xy 120.65 34.29)
+			(xy 120.65 30.48) (xy 120.65 31.75)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "cd8d8330-ed9f-413e-b4af-2709421ba289")
+	)
+	(wire
+		(pts
+			(xy 16.51 146.05) (xy 27.94 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd8e1c5d-145f-4567-8b91-fe4711b04682")
 	)
 	(wire
 		(pts
@@ -3444,7 +4134,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 118.11) (xy 105.41 118.11)
+			(xy 78.74 118.11) (xy 105.41 118.11)
 		)
 		(stroke
 			(width 0)
@@ -3464,6 +4154,26 @@
 	)
 	(wire
 		(pts
+			(xy 157.48 25.4) (xy 165.1 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d50478f4-308c-427d-bb22-2355509df53d")
+	)
+	(wire
+		(pts
+			(xy 201.93 107.95) (xy 213.36 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5d9d602-9453-4da8-9d43-f59750a4592a")
+	)
+	(wire
+		(pts
 			(xy 266.7 102.87) (xy 276.86 102.87)
 		)
 		(stroke
@@ -3471,6 +4181,26 @@
 			(type default)
 		)
 		(uuid "d6a9a33b-0dc5-4cef-9e08-26b820f805d1")
+	)
+	(wire
+		(pts
+			(xy 187.96 148.59) (xy 196.85 148.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7bb49d8-bfe4-48bc-8a86-82428916edd0")
+	)
+	(wire
+		(pts
+			(xy 120.65 31.75) (xy 132.08 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8078665-d3ee-4d65-aadc-60ac5fad142f")
 	)
 	(wire
 		(pts
@@ -3484,6 +4214,36 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 132.08) (xy 27.94 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db0d7eb9-f459-4906-971c-bb6e5909c8c3")
+	)
+	(wire
+		(pts
+			(xy 201.93 110.49) (xy 213.36 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db795567-4a2b-47ed-a4a0-6369522bbc08")
+	)
+	(wire
+		(pts
+			(xy 187.96 109.22) (xy 196.85 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dca892e2-769b-42e0-9afa-1e75bfd68aff")
+	)
+	(wire
+		(pts
 			(xy 120.65 39.37) (xy 120.65 41.91)
 		)
 		(stroke
@@ -3491,6 +4251,16 @@
 			(type default)
 		)
 		(uuid "dd83dafd-aee1-4cc1-9e13-024773471834")
+	)
+	(wire
+		(pts
+			(xy 187.96 124.46) (xy 196.85 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de060917-eee6-4200-80a2-f3c89bccbb54")
 	)
 	(wire
 		(pts
@@ -3524,7 +4294,7 @@
 	)
 	(wire
 		(pts
-			(xy 77.47 147.32) (xy 105.41 147.32)
+			(xy 78.74 147.32) (xy 105.41 147.32)
 		)
 		(stroke
 			(width 0)
@@ -3584,6 +4354,26 @@
 	)
 	(wire
 		(pts
+			(xy 143.51 140.97) (xy 152.4 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e770bc82-ce7b-4232-b18f-458bab0950dd")
+	)
+	(wire
+		(pts
+			(xy 16.51 157.48) (xy 27.94 157.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea478779-0fed-4483-a177-7c4ef2192e6a")
+	)
+	(wire
+		(pts
 			(xy 49.53 38.1) (xy 58.42 38.1)
 		)
 		(stroke
@@ -3604,7 +4394,7 @@
 	)
 	(wire
 		(pts
-			(xy 148.59 187.96) (xy 148.59 189.23)
+			(xy 147.32 187.96) (xy 147.32 189.23)
 		)
 		(stroke
 			(width 0)
@@ -3654,6 +4444,16 @@
 	)
 	(wire
 		(pts
+			(xy 16.51 166.37) (xy 27.94 166.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f13d5cb2-a079-4624-ba77-cc0aca41ead5")
+	)
+	(wire
+		(pts
 			(xy 83.82 68.58) (xy 83.82 80.01)
 		)
 		(stroke
@@ -3671,6 +4471,16 @@
 			(type default)
 		)
 		(uuid "f42e6f0f-7cea-4727-b223-3e3a32151bc7")
+	)
+	(wire
+		(pts
+			(xy 78.74 177.8) (xy 92.71 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6024f9e-439d-4ccd-af26-4023c848056d")
 	)
 	(wire
 		(pts
@@ -3694,7 +4504,27 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 104.14) (xy 149.86 104.14)
+			(xy 199.39 25.4) (xy 209.55 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f7bd66e4-a41e-43fe-941c-8b7186a62888")
+	)
+	(wire
+		(pts
+			(xy 143.51 115.57) (xy 152.4 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f84a4d46-6378-4746-9146-48c4e8a9cdff")
+	)
+	(wire
+		(pts
+			(xy 143.51 104.14) (xy 146.05 104.14)
 		)
 		(stroke
 			(width 0)
@@ -3711,6 +4541,16 @@
 			(type default)
 		)
 		(uuid "f9dfc42c-21b9-49c0-ae9c-4590bc442ba6")
+	)
+	(wire
+		(pts
+			(xy 16.51 160.02) (xy 27.94 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fb077147-a195-4115-a948-0a14fd2ab176")
 	)
 	(wire
 		(pts
@@ -3752,6 +4592,16 @@
 		)
 		(uuid "ff453a56-d1da-4eeb-b2cf-7ed914691429")
 	)
+	(label "U_WARN1"
+		(at 201.93 105.41 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "04198015-46c3-4d92-9c3d-f947752fd8fd")
+	)
 	(label "D+"
 		(at 58.42 50.8 180)
 		(effects
@@ -3762,7 +4612,77 @@
 		)
 		(uuid "05fb4704-4237-415c-adb8-626e413bd335")
 	)
-	(label "REG_1_ALT"
+	(label "C1_SDA"
+		(at 167.64 25.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "0c2a75d3-e1db-48ba-9925-8f3d122b52c3")
+	)
+	(label "RESET"
+		(at 196.85 143.51 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0f69725a-b528-4304-90d0-32ef559080a8")
+	)
+	(label "C2_SDA"
+		(at 167.64 46.99 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "1186ec20-bcf7-4bf8-8153-a4c1decc9aab")
+	)
+	(label "U_STAT2"
+		(at 201.93 110.49 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "12168c9d-6a2d-4368-bf84-6ff52047abbb")
+	)
+	(label "U_STAT1"
+		(at 201.93 113.03 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "12389879-368d-4aa0-9e91-52017a4d6c66")
+	)
+	(label "U_STAT1"
+		(at 16.51 146.05 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "189ba411-bbca-43cf-85c7-40d93d94dde2")
+	)
+	(label "C1_ALERT"
+		(at 167.64 30.48 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "18f87960-12d5-4a91-8561-7908cb78eb9f")
+	)
+	(label "REG_2_ALT"
 		(at 274.32 63.5 180)
 		(effects
 			(font
@@ -3771,6 +4691,16 @@
 			(justify right bottom)
 		)
 		(uuid "1983bb64-cbd3-45be-862a-213a5fc2c912")
+	)
+	(label "C2_ALERT"
+		(at 16.51 137.16 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "1ef46d62-e996-42e5-9761-728c8210a1c9")
 	)
 	(label "REG_1_SDA"
 		(at 274.32 38.1 180)
@@ -3782,6 +4712,46 @@
 		)
 		(uuid "220d8897-767e-4fb6-aa6e-bcda98fa9cf9")
 	)
+	(label "C1_SCL"
+		(at 16.51 118.11 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "246d3924-0287-4f51-8b6c-d7fe08ba6268")
+	)
+	(label "MAIN_TX"
+		(at 92.71 175.26 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "273b8cfc-512a-4c04-b7c3-0779cbcedbf5")
+	)
+	(label "REG_2_SCL"
+		(at 16.51 177.8 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "29852052-248e-48bf-a3e7-bef2b93aa592")
+	)
+	(label "AUX_RX"
+		(at 92.71 186.69 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "2ea476e6-a741-4b9f-bf84-f4dbdc758744")
+	)
 	(label "D-"
 		(at 58.42 45.72 180)
 		(effects
@@ -3791,6 +4761,26 @@
 			(justify right bottom)
 		)
 		(uuid "360f7ae9-a1b0-4d37-b050-74b7c593b9ec")
+	)
+	(label "PGOOD"
+		(at 165.1 25.4 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "363ed2ba-72dc-4550-8e49-3013ddf3dc59")
+	)
+	(label "C1_DVCC"
+		(at 167.64 27.94 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "399fb539-7a9d-4fdf-ac56-eb7a5e738e91")
 	)
 	(label "VSYS"
 		(at 283.21 102.87 180)
@@ -3802,7 +4792,37 @@
 		)
 		(uuid "421cee74-6d7f-4b88-b111-8830d050a865")
 	)
-	(label "REG_1_SDA"
+	(label "C2_SDA"
+		(at 16.51 132.08 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "457dd08c-544b-4e10-8b95-fd9d9577f280")
+	)
+	(label "C2_DVCC"
+		(at 167.64 49.53 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4729c9b3-5b90-4c30-846f-af9a8c6931b9")
+	)
+	(label "OBC_RST"
+		(at 92.71 168.91 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "492bcc86-8f45-4e0e-8d49-d98b67ed1862")
+	)
+	(label "REG_2_SDA"
 		(at 274.32 66.04 180)
 		(effects
 			(font
@@ -3811,6 +4831,16 @@
 			(justify right bottom)
 		)
 		(uuid "4977b981-cffa-42bb-9bb0-87d8d126927b")
+	)
+	(label "D_STAT2"
+		(at 199.39 27.94 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "49a307e4-a1a8-4d08-af87-6fa9a4930a70")
 	)
 	(label "REG_1_ALT"
 		(at 274.32 35.56 180)
@@ -3822,8 +4852,28 @@
 		)
 		(uuid "4afbbe69-acec-41c3-8ef1-48de25908688")
 	)
+	(label "U_WARN1"
+		(at 16.51 140.97 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4c8140f4-62dd-4886-a402-b68126ca3175")
+	)
+	(label "REG_1_SDA"
+		(at 16.51 166.37 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4e820575-5ad2-4e5b-961d-6c8aa247448c")
+	)
 	(label "RESET"
-		(at 15.24 109.22 0)
+		(at 16.51 109.22 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3832,7 +4882,17 @@
 		)
 		(uuid "4fe1fa45-5af8-4324-a422-689f15257b71")
 	)
-	(label "REG_1_ALT"
+	(label "D_WARN1"
+		(at 16.51 152.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "50ae542d-4c40-474d-ac72-0fb51bb86245")
+	)
+	(label "REG_1_SCL"
 		(at 274.32 40.64 180)
 		(effects
 			(font
@@ -3842,8 +4902,98 @@
 		)
 		(uuid "513887d0-fcf7-42b1-929e-3ba6dc53ed6d")
 	)
+	(label "OBC_RST"
+		(at 196.85 137.16 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "55e6c38b-4471-468e-a4c8-9e507e626d76")
+	)
+	(label "REG_2_SDA"
+		(at 16.51 175.26 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "59c77fc1-7bfa-4ae4-849d-2c43cd88683b")
+	)
+	(label "MAIN_TX"
+		(at 196.85 118.11 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "5b192c02-88d6-44a0-8f14-5d91b949f38a")
+	)
+	(label "REG_2_ALT"
+		(at 16.51 172.72 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5bf4819e-411d-4fcd-a4ae-7ddd0c3ee11a")
+	)
+	(label "PGOOD"
+		(at 196.85 109.22 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "5c78fe04-3fb9-4cce-b9e4-c942074d285e")
+	)
+	(label "MAIN_RX"
+		(at 196.85 111.76 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "5f8ff8f3-9346-4cc4-a59b-8c7f0325801a")
+	)
+	(label "D_STAT2"
+		(at 16.51 157.48 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6838c2c8-c86f-45b6-a2d5-a8972fac14d2")
+	)
+	(label "SET1"
+		(at 16.51 184.15 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6a73137b-8472-4c4d-8383-188b98b00ce1")
+	)
+	(label "C1_ALERT"
+		(at 16.51 125.73 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "701579fe-86d8-4959-90de-e9f39102fdb9")
+	)
 	(label "RESET"
-		(at 191.77 143.51 180)
+		(at 275.59 143.51 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3862,6 +5012,26 @@
 		)
 		(uuid "748d29d8-0a5f-4f6d-9bfc-062e3265128f")
 	)
+	(label "REG_1_SCL"
+		(at 16.51 168.91 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "7a6f31c1-52ba-40d3-a125-7991af248c43")
+	)
+	(label "SET0"
+		(at 16.51 181.61 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "8091124c-e35d-4b83-9ca2-4a3540336d8b")
+	)
 	(label "SHIELD"
 		(at 26.67 71.12 180)
 		(effects
@@ -3872,8 +5042,48 @@
 		)
 		(uuid "81727315-41c7-4c4a-a6e2-37dd28ea10b7")
 	)
+	(label "OBC_HRT"
+		(at 92.71 166.37 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "8736c309-f701-4c1d-97aa-3d789751227e")
+	)
+	(label "SET0"
+		(at 275.59 147.32 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "995b32f0-4922-4ccb-ad88-85da66d18fcc")
+	)
+	(label "D_STAT1"
+		(at 199.39 30.48 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a431cd16-e8bd-4d58-9eb0-e52060249e8a")
+	)
+	(label "C1_SCL"
+		(at 167.64 22.86 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a6881bed-be37-4522-b7fb-f29e72600865")
+	)
 	(label "MPPT_V"
-		(at 203.2 140.97 0)
+		(at 201.93 140.97 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3882,7 +5092,27 @@
 		)
 		(uuid "a7bd6ed5-f8ce-4802-9463-4c3e66b0fcc0")
 	)
+	(label "D_WARN2"
+		(at 199.39 25.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a83b3b86-9218-484f-a666-a2226693eb84")
+	)
 	(label "REG_1_ALT"
+		(at 16.51 163.83 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ab9364fb-61b8-4941-bb29-427b29f68172")
+	)
+	(label "REG_2_SCL"
 		(at 274.32 68.58 180)
 		(effects
 			(font
@@ -3892,8 +5122,28 @@
 		)
 		(uuid "adf8b4a4-7b40-4551-bae7-5e59122dc3aa")
 	)
+	(label "C1_SDA"
+		(at 16.51 120.65 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "aead5001-1dce-44f7-b66f-95ccff87fb36")
+	)
+	(label "AUX_TX"
+		(at 92.71 184.15 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b2bb96e6-a32c-40c1-a872-ff949fdacd34")
+	)
 	(label "VSYS"
-		(at 167.64 20.32 0)
+		(at 166.37 20.32 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -3901,6 +5151,126 @@
 			(justify left bottom)
 		)
 		(uuid "b5c37753-5bee-4d33-8e3a-eb8d50b94b0a")
+	)
+	(label "AUX_TX"
+		(at 196.85 130.81 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b652e6ad-8d3f-44a8-8c20-a6cca2debd0a")
+	)
+	(label "MAIN_RX"
+		(at 92.71 177.8 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "bcaeabbf-aef2-4029-a7c8-d44d63eb2555")
+	)
+	(label "WDI"
+		(at 275.59 154.94 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c6922d77-6c04-46c4-950c-378d9ebaff38")
+	)
+	(label "SET1"
+		(at 275.59 151.13 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c7a82f8b-e712-4303-90bc-6efc53ca8a1e")
+	)
+	(label "U_WARN2"
+		(at 201.93 107.95 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "c7b1c7dd-a68b-408a-9144-44f054fc641b")
+	)
+	(label "U_STAT2"
+		(at 16.51 148.59 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "cf7d2f03-9fe3-434a-a5ed-5f29faa2cd6c")
+	)
+	(label "U_WARN2"
+		(at 16.51 143.51 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d3bfa88e-9790-4589-8764-b4f1eae240e1")
+	)
+	(label "D_STAT1"
+		(at 16.51 160.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d4399726-4873-431c-a3f1-2e2e4fd63cc4")
+	)
+	(label "C2_ALERT"
+		(at 167.64 52.07 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d52b6db2-115a-4b7c-9068-9f76d0749a38")
+	)
+	(label "AUX_RX"
+		(at 196.85 124.46 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "d882f166-f9fe-4cbc-969c-9767b62ca2a1")
+	)
+	(label "D_WARN1"
+		(at 199.39 22.86 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "dbdbeee8-89b5-4b8c-8a42-73dbbadb3c45")
+	)
+	(label "D_WARN2"
+		(at 16.51 154.94 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "e066995e-3cae-45c0-beed-981177c602e5")
 	)
 	(label "D+"
 		(at 58.42 48.26 180)
@@ -3912,6 +5282,46 @@
 		)
 		(uuid "e2629fda-8541-4ad8-8f66-e3e7713b861c")
 	)
+	(label "C2_DVCC"
+		(at 16.51 134.62 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "e423efa7-d2fb-4541-9131-55786739a977")
+	)
+	(label "PGOOD"
+		(at 16.51 114.3 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "e8c5246c-b178-4714-a32a-bf62c67917bf")
+	)
+	(label "C1_DVCC"
+		(at 16.51 123.19 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ebe792a8-b69b-4c8f-9ce8-07d055c3960b")
+	)
+	(label "C2_SCL"
+		(at 167.64 44.45 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ee234c37-a1b8-4111-90fa-b6074d676c01")
+	)
 	(label "D-"
 		(at 58.42 43.18 180)
 		(effects
@@ -3921,6 +5331,46 @@
 			(justify right bottom)
 		)
 		(uuid "f30c9174-f3e5-40dd-b4ba-89aea6a69552")
+	)
+	(label "OBC_HRT"
+		(at 196.85 148.59 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "f73eb253-3406-4132-b924-c26d5370d840")
+	)
+	(label "WDI"
+		(at 16.51 186.69 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f9f0fff3-4f48-406a-9282-03bc03ff7e7b")
+	)
+	(label "C2_SCL"
+		(at 16.51 129.54 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "fe968c44-beb6-471d-84a5-7cbe4b87a4ed")
+	)
+	(label "VREF+"
+		(at 91.44 104.14 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "ffb49109-2006-4285-97e2-34ea4705f32f")
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
@@ -3994,7 +5444,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 203.2 146.05 0)
+		(at 201.93 146.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4003,7 +5453,7 @@
 		(fields_autoplaced yes)
 		(uuid "111aa015-6374-4557-8923-d259a7d4d6c9")
 		(property "Reference" "#PWR032"
-			(at 203.2 152.4 0)
+			(at 201.93 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4012,7 +5462,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 203.2 151.13 0)
+			(at 201.93 151.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4021,7 +5471,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 203.2 146.05 0)
+			(at 201.93 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4030,7 +5480,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 203.2 146.05 0)
+			(at 201.93 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4039,7 +5489,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 203.2 146.05 0)
+			(at 201.93 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4332,7 +5782,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 99.06 97.79 0)
+		(at 100.33 104.14 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4340,7 +5790,7 @@
 		(dnp no)
 		(uuid "2da5772b-d6fa-4935-8c6e-14044910997a")
 		(property "Reference" "#PWR04"
-			(at 99.06 101.6 0)
+			(at 104.14 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4349,7 +5799,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 99.06 93.726 0)
+			(at 102.108 102.87 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4357,7 +5807,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 99.06 97.79 0)
+			(at 100.33 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4366,7 +5816,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 99.06 97.79 0)
+			(at 100.33 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4375,7 +5825,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 99.06 97.79 0)
+			(at 100.33 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4464,7 +5914,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 15.24 101.6 0)
+		(at 19.05 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4472,7 +5922,7 @@
 		(dnp no)
 		(uuid "36bbf31b-fb9a-4c05-8ea8-16f7ddc4e27c")
 		(property "Reference" "#PWR033"
-			(at 15.24 105.41 0)
+			(at 19.05 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4481,7 +5931,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 15.24 97.536 0)
+			(at 19.05 97.536 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4489,7 +5939,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 15.24 101.6 0)
+			(at 19.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4498,7 +5948,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 15.24 101.6 0)
+			(at 19.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4507,7 +5957,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 15.24 101.6 0)
+			(at 19.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4598,7 +6048,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 148.59 189.23 0)
+		(at 147.32 189.23 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4607,7 +6057,7 @@
 		(fields_autoplaced yes)
 		(uuid "445568e6-2ab7-468c-8e70-c302490dc790")
 		(property "Reference" "#PWR08"
-			(at 148.59 195.58 0)
+			(at 147.32 195.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4616,7 +6066,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 148.59 194.31 0)
+			(at 147.32 194.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4625,7 +6075,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 148.59 189.23 0)
+			(at 147.32 189.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4634,7 +6084,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 148.59 189.23 0)
+			(at 147.32 189.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4643,7 +6093,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 148.59 189.23 0)
+			(at 147.32 189.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4665,7 +6115,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 149.86 97.79 0)
+		(at 146.05 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4673,7 +6123,7 @@
 		(dnp no)
 		(uuid "47555574-fd32-41c7-8524-e10f2e4326fc")
 		(property "Reference" "#PWR09"
-			(at 149.86 101.6 0)
+			(at 146.05 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4682,7 +6132,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 149.86 93.726 0)
+			(at 146.05 97.536 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4690,7 +6140,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 149.86 97.79 0)
+			(at 146.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4699,7 +6149,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 149.86 97.79 0)
+			(at 146.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4708,7 +6158,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 149.86 97.79 0)
+			(at 146.05 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4730,7 +6180,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 210.82 134.62 0)
+		(at 209.55 134.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4738,7 +6188,7 @@
 		(dnp no)
 		(uuid "50a026f3-365b-403d-8ee2-c11949f74162")
 		(property "Reference" "R132"
-			(at 209.55 133.35 0)
+			(at 208.28 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4747,7 +6197,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 209.55 135.89 0)
+			(at 208.28 135.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4756,7 +6206,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 210.82 134.62 0)
+			(at 209.55 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4765,7 +6215,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 210.82 134.62 0)
+			(at 209.55 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4774,7 +6224,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 210.82 134.62 0)
+			(at 209.55 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4932,6 +6382,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 229.87 57.15 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5f0f4b4f-7946-419c-91e8-22c5773f6f3a")
+		(property "Reference" "#PWR044"
+			(at 229.87 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 229.616 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 229.87 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 229.87 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 229.87 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bda7648-5a77-46e9-82f7-1f5cc06598c6")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "#PWR044")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
 		(at 120.65 45.72 0)
 		(unit 1)
@@ -5066,6 +6581,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 232.41 140.97 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "706ca395-fefe-430a-b55d-8e6c6de66a19")
+		(property "Reference" "#PWR043"
+			(at 232.41 144.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 232.918 136.652 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 232.41 140.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 232.41 140.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 232.41 140.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "390fb96f-c2b6-4a22-a410-9a42f639f087")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "#PWR043")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VBUS")
 		(at 64.77 27.94 0)
 		(unit 1)
@@ -5133,7 +6713,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 210.82 119.38 0)
+		(at 209.55 119.38 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5141,7 +6721,7 @@
 		(dnp no)
 		(uuid "71badc7a-bf23-4fc1-a785-e688011ed1f3")
 		(property "Reference" "R130"
-			(at 209.55 118.11 0)
+			(at 208.28 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5150,7 +6730,7 @@
 			)
 		)
 		(property "Value" "365k"
-			(at 209.55 120.65 0)
+			(at 208.28 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5159,7 +6739,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 210.82 119.38 0)
+			(at 209.55 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5168,7 +6748,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 210.82 119.38 0)
+			(at 209.55 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5177,7 +6757,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 210.82 119.38 0)
+			(at 209.55 119.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5202,16 +6782,15 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 203.2 101.6 0)
+		(at 201.93 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "76197db6-089b-41f9-977d-3a5073881a2b")
 		(property "Reference" "#PWR015"
-			(at 203.2 105.41 0)
+			(at 201.93 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5220,7 +6799,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 203.2 96.52 0)
+			(at 202.184 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5228,7 +6807,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 203.2 101.6 0)
+			(at 201.93 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5237,7 +6816,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 203.2 101.6 0)
+			(at 201.93 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5246,7 +6825,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 203.2 101.6 0)
+			(at 201.93 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5946,7 +7525,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 92.71 97.79 0)
+		(at 100.33 106.68 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5954,7 +7533,7 @@
 		(dnp no)
 		(uuid "9a2c0583-fa60-417e-a7ce-bb925436b3cf")
 		(property "Reference" "#PWR03"
-			(at 92.71 101.6 0)
+			(at 104.14 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5963,7 +7542,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 92.71 93.472 0)
+			(at 101.092 105.41 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5971,7 +7550,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 92.71 97.79 0)
+			(at 100.33 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5980,7 +7559,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 92.71 97.79 0)
+			(at 100.33 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5989,7 +7568,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 92.71 97.79 0)
+			(at 100.33 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6260,7 +7839,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Small_US")
-		(at 210.82 127 0)
+		(at 209.55 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6268,7 +7847,7 @@
 		(dnp no)
 		(uuid "acd589da-5f4d-4d1b-896a-26dc7d792933")
 		(property "Reference" "R131"
-			(at 209.55 125.73 0)
+			(at 208.28 125.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6277,7 +7856,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 209.55 128.27 0)
+			(at 208.28 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6286,7 +7865,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 210.82 127 0)
+			(at 209.55 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6295,7 +7874,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 210.82 127 0)
+			(at 209.55 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6304,7 +7883,7 @@
 			)
 		)
 		(property "Description" "Resistor, small US symbol"
-			(at 210.82 127 0)
+			(at 209.55 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6524,6 +8103,71 @@
 			(project "eps"
 				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
 					(reference "#PWR034")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 241.3 142.24 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c0af9fe5-5b8e-4462-8be7-3e7464a3bba5")
+		(property "Reference" "#PWR036"
+			(at 241.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 241.3 138.176 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 241.3 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 241.3 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "af7cd552-131a-4ba1-8e57-0d357103fcce")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(reference "#PWR036")
 					(unit 1)
 				)
 			)
@@ -7019,7 +8663,7 @@
 		)
 	)
 	(sheet
-		(at 26.67 101.6)
+		(at 27.94 101.6)
 		(size 50.8 90.17)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7035,7 +8679,7 @@
 		)
 		(uuid "01f97f68-bf84-46d4-bbb8-12ed1320856d")
 		(property "Sheetname" "STM32L4"
-			(at 26.67 100.8884 0)
+			(at 27.94 100.8884 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7044,7 +8688,7 @@
 			)
 		)
 		(property "Sheetfile" "stm32l4.kicad_sch"
-			(at 26.67 192.3546 0)
+			(at 27.94 192.3546 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7053,7 +8697,7 @@
 			)
 		)
 		(pin "RAIL_1_ON" bidirectional
-			(at 77.47 109.22 0)
+			(at 78.74 109.22 0)
 			(uuid "de0c6e6f-43a4-4488-90f1-ef60b1a8ceed")
 			(effects
 				(font
@@ -7063,7 +8707,7 @@
 			)
 		)
 		(pin "RAIL_1_RST" output
-			(at 77.47 111.76 0)
+			(at 78.74 111.76 0)
 			(uuid "819afb8e-f470-4402-af97-ef7ab5a7d18e")
 			(effects
 				(font
@@ -7073,7 +8717,7 @@
 			)
 		)
 		(pin "RAIL_2_ON" bidirectional
-			(at 77.47 115.57 0)
+			(at 78.74 115.57 0)
 			(uuid "e08704d2-2f46-4317-b4d5-a765a9f17603")
 			(effects
 				(font
@@ -7083,7 +8727,7 @@
 			)
 		)
 		(pin "RAIL_2_RST" output
-			(at 77.47 118.11 0)
+			(at 78.74 118.11 0)
 			(uuid "66160ea1-6466-4c8d-8bff-d947c53650d9")
 			(effects
 				(font
@@ -7093,7 +8737,7 @@
 			)
 		)
 		(pin "RAIL_3_ON" bidirectional
-			(at 77.47 121.92 0)
+			(at 78.74 121.92 0)
 			(uuid "2c2ee582-6d1b-444a-83a7-b2032bc6322c")
 			(effects
 				(font
@@ -7103,7 +8747,7 @@
 			)
 		)
 		(pin "RAIL_3_RST" output
-			(at 77.47 124.46 0)
+			(at 78.74 124.46 0)
 			(uuid "7f3399db-6390-49e2-82d1-bb72b71cd331")
 			(effects
 				(font
@@ -7113,7 +8757,7 @@
 			)
 		)
 		(pin "RAIL_4_ON" bidirectional
-			(at 77.47 128.27 0)
+			(at 78.74 128.27 0)
 			(uuid "604e8a0d-b050-4e0e-9a92-a9cd02a9710d")
 			(effects
 				(font
@@ -7123,7 +8767,7 @@
 			)
 		)
 		(pin "RAIL_4_RST" output
-			(at 77.47 130.81 0)
+			(at 78.74 130.81 0)
 			(uuid "8493941a-d589-40c8-8bf6-9fb71ab1e155")
 			(effects
 				(font
@@ -7133,7 +8777,7 @@
 			)
 		)
 		(pin "RAIL_5_ON" bidirectional
-			(at 77.47 134.62 0)
+			(at 78.74 134.62 0)
 			(uuid "8ece85eb-9541-4e30-858d-dc77d4c71fc2")
 			(effects
 				(font
@@ -7143,7 +8787,7 @@
 			)
 		)
 		(pin "RAIL_5_RST" output
-			(at 77.47 137.16 0)
+			(at 78.74 137.16 0)
 			(uuid "69d2601f-145f-4eb6-b857-66731aefc1f7")
 			(effects
 				(font
@@ -7153,7 +8797,7 @@
 			)
 		)
 		(pin "RAIL_6_ON" bidirectional
-			(at 77.47 140.97 0)
+			(at 78.74 140.97 0)
 			(uuid "da85091d-913f-4be9-8224-e7bb38165ce5")
 			(effects
 				(font
@@ -7163,7 +8807,7 @@
 			)
 		)
 		(pin "RAIL_6_RST" output
-			(at 77.47 143.51 0)
+			(at 78.74 143.51 0)
 			(uuid "cf287f0a-a0f8-4d49-89c7-5ee1248c2743")
 			(effects
 				(font
@@ -7173,7 +8817,7 @@
 			)
 		)
 		(pin "RAIL_7_ON" bidirectional
-			(at 77.47 147.32 0)
+			(at 78.74 147.32 0)
 			(uuid "4eee1d9e-9827-40ec-a517-b5eac02d5c0d")
 			(effects
 				(font
@@ -7183,7 +8827,7 @@
 			)
 		)
 		(pin "RAIL_7_RST" output
-			(at 77.47 149.86 0)
+			(at 78.74 149.86 0)
 			(uuid "e232932e-25e7-41e7-944c-9230ec0210a3")
 			(effects
 				(font
@@ -7193,7 +8837,7 @@
 			)
 		)
 		(pin "RAIL_8_ON" bidirectional
-			(at 77.47 153.67 0)
+			(at 78.74 153.67 0)
 			(uuid "7a687e0f-4dea-4a4f-962d-fc3ea1dd1228")
 			(effects
 				(font
@@ -7203,7 +8847,7 @@
 			)
 		)
 		(pin "RAIL_8_RST" output
-			(at 77.47 156.21 0)
+			(at 78.74 156.21 0)
 			(uuid "2e2ee5f8-710b-4200-8b7e-0261535e9b3f")
 			(effects
 				(font
@@ -7213,7 +8857,7 @@
 			)
 		)
 		(pin "RESET" input
-			(at 26.67 109.22 180)
+			(at 27.94 109.22 180)
 			(uuid "fd599a86-3f47-478c-ba14-b7bf42df31b7")
 			(effects
 				(font
@@ -7223,7 +8867,7 @@
 			)
 		)
 		(pin "VDD" input
-			(at 26.67 104.14 180)
+			(at 27.94 104.14 180)
 			(uuid "b894f49c-a9fa-4f04-a685-57af6dd8ec62")
 			(effects
 				(font
@@ -7233,8 +8877,328 @@
 			)
 		)
 		(pin "VREF+" output
-			(at 77.47 104.14 0)
+			(at 78.74 104.14 0)
 			(uuid "a8e7a429-ba6c-4ca7-ab2b-6ffee12a3c64")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "C1_SCL" output
+			(at 27.94 118.11 180)
+			(uuid "9a6b0ee8-5f61-40fa-bfe5-30f8d95255b7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "PGOOD" input
+			(at 27.94 114.3 180)
+			(uuid "f08ea682-4940-45c6-9f53-741e8044d473")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C1_ALERT" input
+			(at 27.94 125.73 180)
+			(uuid "fc3613b2-a443-4995-97e2-b2ebf665e276")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C1_DVCC" output
+			(at 27.94 123.19 180)
+			(uuid "183f7afd-627f-4532-a70e-d20a2f91436a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C1_SDA" bidirectional
+			(at 27.94 120.65 180)
+			(uuid "7455bd7c-5479-43c0-8e61-d512977587c8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C2_ALERT" input
+			(at 27.94 137.16 180)
+			(uuid "4a809969-9462-49dd-8db7-1a17b3205d59")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C2_DVCC" output
+			(at 27.94 134.62 180)
+			(uuid "c2aa0f22-5bb6-463d-83bf-d632d01f0690")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C2_SCL" output
+			(at 27.94 129.54 180)
+			(uuid "14da149e-224a-468d-b344-d34ad71667fc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "C2_SDA" bidirectional
+			(at 27.94 132.08 180)
+			(uuid "7c5eb463-2d3c-4056-a632-8e0e7c8e35d5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "U_STAT1" input
+			(at 27.94 146.05 180)
+			(uuid "8ae46ed6-3674-4856-893d-ab04a9ee12c0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "U_STAT2" input
+			(at 27.94 148.59 180)
+			(uuid "07086b75-0e79-4ee3-8980-6838691e6b32")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "U_WARN1" input
+			(at 27.94 140.97 180)
+			(uuid "d40ac87e-dc1a-459f-8ee0-2f123a890e9b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "U_WARN2" input
+			(at 27.94 143.51 180)
+			(uuid "68f640a7-1e07-429f-a097-ae4897f45db1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "D_STAT1" input
+			(at 27.94 160.02 180)
+			(uuid "f38faeb2-7a64-4df0-962a-180d0d59432d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "D_STAT2" input
+			(at 27.94 157.48 180)
+			(uuid "090252fe-3d83-4b18-af50-536af1dc575a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "D_WARN1" input
+			(at 27.94 154.94 180)
+			(uuid "483faee4-a0fc-41f4-a73f-cc29856e550f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "D_WARN2" input
+			(at 27.94 152.4 180)
+			(uuid "e4e9ac7a-36db-442f-8d42-8375aa8f0559")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_1_ALT" input
+			(at 27.94 163.83 180)
+			(uuid "41573ca1-12a9-406f-9c23-718c2a9fffc6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_1_SCL" output
+			(at 27.94 168.91 180)
+			(uuid "51d098d0-af29-4e51-a252-bce04556679a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_1_SDA" bidirectional
+			(at 27.94 166.37 180)
+			(uuid "21b0fbb4-457c-484f-a069-d3e98eb4c852")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_2_ALT" input
+			(at 27.94 172.72 180)
+			(uuid "c9178f45-64d0-489c-bd34-6d7dd1086d37")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_2_SCL" output
+			(at 27.94 177.8 180)
+			(uuid "04bd3506-796b-4721-96e0-92e931e44a4c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "REG_2_SDA" bidirectional
+			(at 27.94 175.26 180)
+			(uuid "2e587c0c-47cc-48ee-8fb4-2dd6929363ef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "SET0" output
+			(at 27.94 181.61 180)
+			(uuid "e3b5b890-e5f4-4dbc-905b-3459e4b65a98")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "SET1" output
+			(at 27.94 184.15 180)
+			(uuid "34a7bcbf-fb51-462d-86c9-6dc69ad0e9f1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "WDI" output
+			(at 27.94 186.69 180)
+			(uuid "d4399720-f91f-4882-bc79-e0bf4e3cf6e9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "SYSTEM_UART_AUX_RX" input
+			(at 78.74 186.69 0)
+			(uuid "37fb032f-2e97-4ac8-8065-d9ebf3aeefd0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_UART_AUX_TX" output
+			(at 78.74 184.15 0)
+			(uuid "43e025ed-0345-4813-b821-187d185e2b4b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_UART_MAIN_RX" input
+			(at 78.74 177.8 0)
+			(uuid "a2daa32b-1e10-41c4-8dde-877a5e7b008b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_UART_MAIN_TX" output
+			(at 78.74 175.26 0)
+			(uuid "31e0549e-1b74-4f9f-959b-39dc119275f1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "EPS_OBC_RESET" output
+			(at 78.74 168.91 0)
+			(uuid "64e916c5-4340-4b86-835b-a48910ba613a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "OBC_HEARTBEAT" input
+			(at 78.74 166.37 0)
+			(uuid "77a0cc6e-6f35-4ac3-8297-3bb27f47e804")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8084,7 +10048,7 @@
 			)
 		)
 		(pin "DVCC" input
-			(at 177.8 50.8 180)
+			(at 177.8 49.53 180)
 			(uuid "27da158a-13b6-41ed-ac00-79a8165aa94a")
 			(effects
 				(font
@@ -8094,7 +10058,7 @@
 			)
 		)
 		(pin "SCL" input
-			(at 177.8 45.72 180)
+			(at 177.8 44.45 180)
 			(uuid "1af9c982-b965-4bf8-bc55-8288459266fd")
 			(effects
 				(font
@@ -8104,7 +10068,7 @@
 			)
 		)
 		(pin "SDA" bidirectional
-			(at 177.8 48.26 180)
+			(at 177.8 46.99 180)
 			(uuid "22114255-b3d1-4d41-bc6e-15d3c1cdabe8")
 			(effects
 				(font
@@ -8114,13 +10078,13 @@
 			)
 		)
 		(pin "SMBALERT" output
-			(at 195.58 44.45 0)
+			(at 177.8 52.07 180)
 			(uuid "c96c0810-b630-4aef-9d5f-6cf40b9bb8fd")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
 		(instances
@@ -8381,7 +10345,7 @@
 			)
 		)
 		(pin "DVCC" input
-			(at 177.8 29.21 180)
+			(at 177.8 27.94 180)
 			(uuid "9747b6f0-db05-4b26-8616-1ac30084e302")
 			(effects
 				(font
@@ -8391,7 +10355,7 @@
 			)
 		)
 		(pin "SCL" input
-			(at 177.8 24.13 180)
+			(at 177.8 22.86 180)
 			(uuid "290f5e7c-53da-4db4-b8d0-44dfaeb15782")
 			(effects
 				(font
@@ -8401,7 +10365,7 @@
 			)
 		)
 		(pin "SDA" bidirectional
-			(at 177.8 26.67 180)
+			(at 177.8 25.4 180)
 			(uuid "e252b193-4e59-400f-aafb-584ed6b4e8d4")
 			(effects
 				(font
@@ -8411,13 +10375,13 @@
 			)
 		)
 		(pin "SMBALERT" output
-			(at 195.58 22.86 0)
+			(at 177.8 30.48 180)
 			(uuid "1900d1c0-4360-4535-bc1f-5750c1305c58")
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
 		(instances
@@ -8429,7 +10393,209 @@
 		)
 	)
 	(sheet
-		(at 162.56 139.7)
+		(at 152.4 101.6)
+		(size 35.56 55.88)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0.0000)
+		)
+		(uuid "b219b5f3-4d87-4e00-9626-11450f76e9f7")
+		(property "Sheetname" "Inter-Board Connector"
+			(at 152.4 100.8884 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "inter_board_connector.kicad_sch"
+			(at 152.4 158.0646 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "RAIL_1_VOUT" input
+			(at 152.4 109.22 180)
+			(uuid "8bb53f5e-fc61-4f10-b270-f75f07c929bd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_2_VOUT" input
+			(at 152.4 115.57 180)
+			(uuid "228ac9bd-0aee-4d54-b682-8b80897ef041")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_3_VOUT" input
+			(at 152.4 121.92 180)
+			(uuid "66da9b6a-6bff-436d-8435-b7c256fcd2c0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_4_VOUT" input
+			(at 152.4 128.27 180)
+			(uuid "fbc49fa6-16bf-4924-859a-296b11508ec5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_5_VOUT" input
+			(at 152.4 134.62 180)
+			(uuid "3c5f3613-8428-4304-a208-149feb6b07e2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_6_VOUT" input
+			(at 152.4 140.97 180)
+			(uuid "c3a09e0d-6508-469d-9b73-c310ee5fbe5f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_7_VOUT" input
+			(at 152.4 147.32 180)
+			(uuid "d8dfcc70-13fe-4585-b1a1-16adb1bcadd4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "RAIL_8_VOUT" input
+			(at 152.4 153.67 180)
+			(uuid "6eb93b7c-6333-4a7c-943c-72dd425421c5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "EPS_PGOOD" input
+			(at 187.96 109.22 0)
+			(uuid "f979542b-c574-4caf-8c3b-324145c12459")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_AUX_UART_RX" input
+			(at 187.96 124.46 0)
+			(uuid "ebf31877-ddc9-437e-aed5-d0359d2a48ed")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_AUX_UART_TX" input
+			(at 187.96 130.81 0)
+			(uuid "2fc4770b-c0a8-4ced-a255-80b010075992")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_MAIN_UART_RX" input
+			(at 187.96 111.76 0)
+			(uuid "374c24a3-7428-4f7c-a05e-a49e107c92dd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SYSTEM_MAIN_UART_TX" input
+			(at 187.96 118.11 0)
+			(uuid "b09c4ff1-822b-4b73-a5c9-7663825f153e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "EPS_OBC_RESET" input
+			(at 187.96 137.16 0)
+			(uuid "0eb01d8e-049e-4284-957d-9c383e5319b0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "OBC_EPS_RESET" output
+			(at 187.96 143.51 0)
+			(uuid "55068fc7-8002-4fd0-b4d1-6385bfbbac29")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "OBC_HEARTBEAT" output
+			(at 187.96 148.59 0)
+			(uuid "f6b683e4-f5df-47e4-93c5-16ce320e58ad")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180"
+					(page "26")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 246.38 139.7)
 		(size 19.05 17.78)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8445,7 +10611,7 @@
 		)
 		(uuid "b94b8a9c-8452-423f-9ecc-cad4cd57e214")
 		(property "Sheetname" "Watchdog Timer"
-			(at 162.56 138.9884 0)
+			(at 246.38 138.9884 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8454,7 +10620,7 @@
 			)
 		)
 		(property "Sheetfile" "watchdog_timer.kicad_sch"
-			(at 162.56 158.0646 0)
+			(at 246.38 158.0646 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8463,7 +10629,7 @@
 			)
 		)
 		(pin "RESET" output
-			(at 181.61 143.51 0)
+			(at 265.43 143.51 0)
 			(uuid "896df96d-e1a5-4f65-b12d-e71b65963426")
 			(effects
 				(font
@@ -8473,7 +10639,7 @@
 			)
 		)
 		(pin "SET0" input
-			(at 181.61 147.32 0)
+			(at 265.43 147.32 0)
 			(uuid "bc6feaf2-9af3-4cd4-94d4-2a16dbc2bc35")
 			(effects
 				(font
@@ -8483,7 +10649,7 @@
 			)
 		)
 		(pin "SET1" input
-			(at 181.61 151.13 0)
+			(at 265.43 151.13 0)
 			(uuid "5ec28042-b46d-4d31-9585-2ce34b195e0a")
 			(effects
 				(font
@@ -8493,7 +10659,7 @@
 			)
 		)
 		(pin "VDD" input
-			(at 162.56 143.51 180)
+			(at 246.38 143.51 180)
 			(uuid "44d2f7a3-1897-408c-8823-e128a7416e24")
 			(effects
 				(font
@@ -8503,7 +10669,7 @@
 			)
 		)
 		(pin "WDI" input
-			(at 181.61 154.94 0)
+			(at 265.43 154.94 0)
 			(uuid "1ae39f93-5d3e-4423-a97d-b6ff7ddd0ac6")
 			(effects
 				(font
@@ -8583,7 +10749,7 @@
 		)
 	)
 	(sheet
-		(at 214.63 101.6)
+		(at 213.36 101.6)
 		(size 16.51 44.45)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8598,7 +10764,7 @@
 		)
 		(uuid "ea4c86fa-6561-475a-a54d-b57bbe53e74a")
 		(property "Sheetname" "Power Path Ideal Diode1"
-			(at 211.328 100.838 0)
+			(at 210.058 100.838 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8616,7 +10782,7 @@
 			)
 		)
 		(pin "3V3" input
-			(at 231.14 143.51 0)
+			(at 229.87 143.51 0)
 			(uuid "4dea1472-5153-4fef-803b-cbb7686feb82")
 			(effects
 				(font
@@ -8626,7 +10792,7 @@
 			)
 		)
 		(pin "GND" input
-			(at 214.63 143.51 180)
+			(at 213.36 143.51 180)
 			(uuid "bf36f1b7-43f4-4ebe-8a50-3eb9884f52e0")
 			(effects
 				(font
@@ -8636,7 +10802,7 @@
 			)
 		)
 		(pin "STAT1" output
-			(at 214.63 113.03 180)
+			(at 213.36 113.03 180)
 			(uuid "ff03d73b-a64b-45ca-9312-26a4ba797ea9")
 			(effects
 				(font
@@ -8646,7 +10812,7 @@
 			)
 		)
 		(pin "VIN1" input
-			(at 214.63 102.87 180)
+			(at 213.36 102.87 180)
 			(uuid "67e82985-542d-4d2a-8fa2-0e1d53ab2eb1")
 			(effects
 				(font
@@ -8656,7 +10822,7 @@
 			)
 		)
 		(pin "VOUT" input
-			(at 231.14 102.87 0)
+			(at 229.87 102.87 0)
 			(uuid "48ef5a02-c326-4287-8d31-12bf20c04af7")
 			(effects
 				(font
@@ -8666,7 +10832,7 @@
 			)
 		)
 		(pin "STAT2" output
-			(at 214.63 110.49 180)
+			(at 213.36 110.49 180)
 			(uuid "1437c587-ed62-4956-8e3b-ef4a6f94cdc1")
 			(effects
 				(font
@@ -8676,7 +10842,7 @@
 			)
 		)
 		(pin "WARN1" output
-			(at 214.63 107.95 180)
+			(at 213.36 105.41 180)
 			(uuid "b733227f-ece5-4d37-ae95-f3936a53becd")
 			(effects
 				(font
@@ -8686,7 +10852,7 @@
 			)
 		)
 		(pin "WARN2" output
-			(at 214.63 105.41 180)
+			(at 213.36 107.95 180)
 			(uuid "2794cf9a-a5f5-4a22-b272-63dfa229f637")
 			(effects
 				(font
@@ -8696,7 +10862,7 @@
 			)
 		)
 		(pin "VIN2" input
-			(at 214.63 140.97 180)
+			(at 213.36 140.97 180)
 			(uuid "283ca7c6-d75b-4bc7-8627-64540d3d36c1")
 			(effects
 				(font
@@ -8706,7 +10872,7 @@
 			)
 		)
 		(pin "R1+" input
-			(at 214.63 116.84 180)
+			(at 213.36 116.84 180)
 			(uuid "598c43cc-6f07-414b-ad07-e0ff515131f0")
 			(effects
 				(font
@@ -8716,7 +10882,7 @@
 			)
 		)
 		(pin "R1-" input
-			(at 214.63 121.92 180)
+			(at 213.36 121.92 180)
 			(uuid "f0401196-69b1-412e-8457-515ba514c9cc")
 			(effects
 				(font
@@ -8726,7 +10892,7 @@
 			)
 		)
 		(pin "R2+" input
-			(at 214.63 124.46 180)
+			(at 213.36 124.46 180)
 			(uuid "06ff975f-1e49-4b64-b3a7-caae4dd5ee9b")
 			(effects
 				(font
@@ -8736,7 +10902,7 @@
 			)
 		)
 		(pin "R2-" input
-			(at 214.63 129.54 180)
+			(at 213.36 129.54 180)
 			(uuid "a11224c3-f528-4988-926d-90036ff7068e")
 			(effects
 				(font
@@ -8746,7 +10912,7 @@
 			)
 		)
 		(pin "R3+" input
-			(at 214.63 132.08 180)
+			(at 213.36 132.08 180)
 			(uuid "958bbc14-06fc-4638-b37d-5c1ea3fe6e19")
 			(effects
 				(font
@@ -8756,7 +10922,7 @@
 			)
 		)
 		(pin "R3-" input
-			(at 214.63 137.16 180)
+			(at 213.36 137.16 180)
 			(uuid "ec4d9f27-81e4-47ff-a08f-90b614a4039b")
 			(effects
 				(font
@@ -8867,7 +11033,7 @@
 			)
 		)
 		(pin "WARN1" output
-			(at 209.55 25.4 180)
+			(at 209.55 22.86 180)
 			(uuid "14fb70be-d1a3-42d3-85bc-446f1c773a6b")
 			(effects
 				(font
@@ -8877,7 +11043,7 @@
 			)
 		)
 		(pin "WARN2" output
-			(at 209.55 22.86 180)
+			(at 209.55 25.4 180)
 			(uuid "6b17eed0-48f4-4128-a687-7282ed324387")
 			(effects
 				(font

--- a/eps/hardware/inter_board_connector.kicad_sch
+++ b/eps/hardware/inter_board_connector.kicad_sch
@@ -1,0 +1,2434 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "5b6c93eb-2114-4301-ac3e-5c815da4e746")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Connector_Generic:Conn_02x20_Counter_Clockwise"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 1.27 25.4 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_02x20_Counter_Clockwise"
+				(at 1.27 -27.94 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, double row, 02x20, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_2x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_02x20_Counter_Clockwise_1_1"
+				(rectangle
+					(start -1.27 24.13)
+					(end 3.81 -26.67)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 22.987)
+					(end 0 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 20.447)
+					(end 0 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -22.733)
+					(end 0 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -25.273)
+					(end 0 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 22.987)
+					(end 2.54 22.733)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 20.447)
+					(end 2.54 20.193)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 17.907)
+					(end 2.54 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 15.367)
+					(end 2.54 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 12.827)
+					(end 2.54 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 10.287)
+					(end 2.54 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 7.747)
+					(end 2.54 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 5.207)
+					(end 2.54 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 2.667)
+					(end 2.54 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 0.127)
+					(end 2.54 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -2.413)
+					(end 2.54 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -4.953)
+					(end 2.54 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -7.493)
+					(end 2.54 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -10.033)
+					(end 2.54 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -12.573)
+					(end 2.54 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -15.113)
+					(end 2.54 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -17.653)
+					(end 2.54 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -20.193)
+					(end 2.54 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -22.733)
+					(end 2.54 -22.987)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.81 -25.273)
+					(end 2.54 -25.527)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 22.86 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 20.32 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -22.86 0)
+					(length 3.81)
+					(name "Pin_19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -25.4 0)
+					(length 3.81)
+					(name "Pin_20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 22.86 180)
+					(length 3.81)
+					(name "Pin_40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 20.32 180)
+					(length 3.81)
+					(name "Pin_39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 17.78 180)
+					(length 3.81)
+					(name "Pin_38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 15.24 180)
+					(length 3.81)
+					(name "Pin_37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 12.7 180)
+					(length 3.81)
+					(name "Pin_36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 10.16 180)
+					(length 3.81)
+					(name "Pin_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 7.62 180)
+					(length 3.81)
+					(name "Pin_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 5.08 180)
+					(length 3.81)
+					(name "Pin_33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 2.54 180)
+					(length 3.81)
+					(name "Pin_32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 0 180)
+					(length 3.81)
+					(name "Pin_31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -2.54 180)
+					(length 3.81)
+					(name "Pin_30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -5.08 180)
+					(length 3.81)
+					(name "Pin_29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -7.62 180)
+					(length 3.81)
+					(name "Pin_28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -10.16 180)
+					(length 3.81)
+					(name "Pin_27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -12.7 180)
+					(length 3.81)
+					(name "Pin_26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -15.24 180)
+					(length 3.81)
+					(name "Pin_25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -17.78 180)
+					(length 3.81)
+					(name "Pin_24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -20.32 180)
+					(length 3.81)
+					(name "Pin_23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -22.86 180)
+					(length 3.81)
+					(name "Pin_22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -25.4 180)
+					(length 3.81)
+					(name "Pin_21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(rectangle
+		(start 101.6 68.072)
+		(end 190.5 127)
+		(stroke
+			(width 0)
+			(type dash)
+		)
+		(fill
+			(type none)
+		)
+		(uuid ef018846-734e-43e1-bc53-bd6499cabf7f)
+	)
+	(text "Inter-Board Connector"
+		(exclude_from_sim no)
+		(at 112.522 66.802 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+		)
+		(uuid "7724b4a4-6bb1-4b9c-b0fc-b5f06edf4460")
+	)
+	(no_connect
+		(at 152.4 101.6)
+		(uuid "0484ece0-cca6-4db9-8a56-cb353ff06e39")
+	)
+	(no_connect
+		(at 152.4 78.74)
+		(uuid "0aa5a09d-3377-4a74-84a8-0935fc7bdf58")
+	)
+	(no_connect
+		(at 152.4 109.22)
+		(uuid "0c82cd8f-7bb1-434c-aaeb-5616a21916dd")
+	)
+	(no_connect
+		(at 152.4 114.3)
+		(uuid "0fefad34-114d-4f1f-aeea-0f5f0108f2c8")
+	)
+	(no_connect
+		(at 152.4 83.82)
+		(uuid "13843197-89c9-4c2b-8e9c-16271b449c36")
+	)
+	(no_connect
+		(at 152.4 86.36)
+		(uuid "2030bf9e-2336-4146-b5ec-999945cfdaf4")
+	)
+	(no_connect
+		(at 139.7 114.3)
+		(uuid "3af5872d-8e0d-4efa-b648-8261bb55e76e")
+	)
+	(no_connect
+		(at 152.4 106.68)
+		(uuid "3dd01838-6ed6-4d38-b56c-323ba850c66f")
+	)
+	(no_connect
+		(at 152.4 116.84)
+		(uuid "3efe7b94-42e3-4811-886e-3565a0cd60c2")
+	)
+	(no_connect
+		(at 139.7 116.84)
+		(uuid "6f4b939f-4ffc-42a0-ab39-75d302dd0f88")
+	)
+	(no_connect
+		(at 152.4 104.14)
+		(uuid "700c532c-d99f-43c1-87e8-e545a485634d")
+	)
+	(no_connect
+		(at 152.4 111.76)
+		(uuid "7e67426f-6f3e-4b85-9f80-a0a12d6569d7")
+	)
+	(no_connect
+		(at 139.7 111.76)
+		(uuid "854b9c5a-8433-4426-a489-56249b48c4a2")
+	)
+	(no_connect
+		(at 152.4 93.98)
+		(uuid "85ca9088-e35d-4f81-bfc1-7254777cf1f8")
+	)
+	(no_connect
+		(at 152.4 96.52)
+		(uuid "a4fefd26-8464-4a4a-8e36-6c3bd131dfc9")
+	)
+	(no_connect
+		(at 152.4 91.44)
+		(uuid "b61ff1dd-c24e-4be5-a5d0-3eaa19047f18")
+	)
+	(no_connect
+		(at 152.4 81.28)
+		(uuid "c11ade3a-dc81-4c0a-9d5d-86afac4f9aa2")
+	)
+	(no_connect
+		(at 152.4 88.9)
+		(uuid "d0e3f29d-a2eb-492f-b465-d84789c2fbae")
+	)
+	(wire
+		(pts
+			(xy 127 106.68) (xy 139.7 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14f4eec6-1c4a-4e4d-90c5-f81a42c96785")
+	)
+	(wire
+		(pts
+			(xy 127 93.98) (xy 139.7 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "32f608d6-e9fb-494c-9e46-250a43c11227")
+	)
+	(wire
+		(pts
+			(xy 127 109.22) (xy 139.7 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c7231be-0e8b-44f4-aa48-9a2b67ff466b")
+	)
+	(wire
+		(pts
+			(xy 152.4 124.46) (xy 165.1 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53ff27cd-1960-4b8d-ba94-109ce61d4e15")
+	)
+	(wire
+		(pts
+			(xy 127 88.9) (xy 139.7 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57190992-6497-4696-bdc3-8e7b514b6c2e")
+	)
+	(wire
+		(pts
+			(xy 127 76.2) (xy 139.7 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f574f06-fc45-4417-a636-18d5e852bc2e")
+	)
+	(wire
+		(pts
+			(xy 165.1 99.06) (xy 152.4 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "67545631-4c04-476b-8d85-0da7fd213e29")
+	)
+	(wire
+		(pts
+			(xy 127 96.52) (xy 139.7 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c8a71b0-49c6-4e42-a175-1d0800a71d6c")
+	)
+	(wire
+		(pts
+			(xy 127 101.6) (xy 139.7 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70d9517b-14db-4afd-9b47-8d4b4139bf78")
+	)
+	(wire
+		(pts
+			(xy 152.4 76.2) (xy 165.1 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7354aeca-4467-437d-8a44-6e07e5002193")
+	)
+	(wire
+		(pts
+			(xy 127 86.36) (xy 139.7 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7551cba9-8222-43e9-8663-3f64b3ca497b")
+	)
+	(wire
+		(pts
+			(xy 165.1 119.38) (xy 152.4 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79607d2b-c336-4c44-85e6-8710e3dc4856")
+	)
+	(wire
+		(pts
+			(xy 127 99.06) (xy 139.7 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a8a28a1-2d23-45c0-9556-937fe8fea5a2")
+	)
+	(wire
+		(pts
+			(xy 127 119.38) (xy 139.7 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a5b3ab01-3fdc-4fb7-b498-eabf44d4b914")
+	)
+	(wire
+		(pts
+			(xy 127 104.14) (xy 139.7 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8712666-01ee-4954-885b-01327d16cd06")
+	)
+	(wire
+		(pts
+			(xy 127 83.82) (xy 139.7 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6f481da-dcb7-4641-996d-f0bd583a0ef9")
+	)
+	(wire
+		(pts
+			(xy 127 91.44) (xy 139.7 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbcf54e1-c5ce-4d66-80df-33739abccdd5")
+	)
+	(wire
+		(pts
+			(xy 127 121.92) (xy 139.7 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d11dc94b-5120-4a35-904f-3f688c6b1a15")
+	)
+	(wire
+		(pts
+			(xy 127 124.46) (xy 139.7 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8288a18-fdbd-47af-b4b0-b3f053fd5b77")
+	)
+	(wire
+		(pts
+			(xy 127 81.28) (xy 139.7 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8ea6a1b-1fde-4657-a9ee-430996d36a11")
+	)
+	(wire
+		(pts
+			(xy 127 78.74) (xy 139.7 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f29afb38-4640-4cd1-9dd6-d307aeda6eb5")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 152.4 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ff6fa254-2e0b-4f30-82cd-3f1915da0b3a")
+	)
+	(hierarchical_label "OBC_HEARTBEAT"
+		(shape output)
+		(at 127 109.22 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "14070c90-867f-4091-8139-0af3c5630415")
+	)
+	(hierarchical_label "RAIL_4_VOUT"
+		(shape input)
+		(at 127 86.36 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1b624d96-904e-49cf-8a00-3b200584bc8f")
+	)
+	(hierarchical_label "RAIL_6_VOUT"
+		(shape input)
+		(at 127 91.44 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "33de8cd7-813b-4d3f-9efd-26fae3c9c20d")
+	)
+	(hierarchical_label "SYSTEM_AUX_UART_RX"
+		(shape input)
+		(at 165.1 119.38 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4faafefb-9e3e-4621-a609-472b0ab5fcc6")
+	)
+	(hierarchical_label "RAIL_7_VOUT"
+		(shape input)
+		(at 127 93.98 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5666d796-5765-459d-b103-9c671d203231")
+	)
+	(hierarchical_label "SYSTEM_AUX_UART_TX"
+		(shape input)
+		(at 165.1 121.92 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "83f11443-51f7-46ca-8c18-d39a9afd4144")
+	)
+	(hierarchical_label "EPS_OBC_RESET"
+		(shape input)
+		(at 127 104.14 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8cc41ff5-3838-4405-801d-5f1ab17705c1")
+	)
+	(hierarchical_label "EPS_PGOOD"
+		(shape input)
+		(at 127 101.6 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "954ee672-49aa-472f-8311-d5344aa2d36d")
+	)
+	(hierarchical_label "RAIL_2_VOUT"
+		(shape input)
+		(at 127 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a3d744a8-c3f8-4a0b-b148-23534d39cd94")
+	)
+	(hierarchical_label "RAIL_5_VOUT"
+		(shape input)
+		(at 127 88.9 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bf59e519-492d-4eda-bc36-22e893474a55")
+	)
+	(hierarchical_label "RAIL_8_VOUT"
+		(shape input)
+		(at 127 96.52 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c2cfa3e4-a515-4693-a5c3-f795d9a86828")
+	)
+	(hierarchical_label "SYSTEM_MAIN_UART_TX"
+		(shape input)
+		(at 127 121.92 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c5a8bafc-4686-4c68-97fd-1a0a05176590")
+	)
+	(hierarchical_label "RAIL_1_VOUT"
+		(shape input)
+		(at 127 78.74 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c61b4dd2-b337-4d21-99b9-21a670257275")
+	)
+	(hierarchical_label "RAIL_3_VOUT"
+		(shape input)
+		(at 127 83.82 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "dea46d62-a4f2-429d-8eea-bbab48f3c384")
+	)
+	(hierarchical_label "OBC_EPS_RESET"
+		(shape output)
+		(at 127 106.68 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e9fd6f1f-44d6-413b-89bc-0926828b44df")
+	)
+	(hierarchical_label "SYSTEM_MAIN_UART_RX"
+		(shape input)
+		(at 127 119.38 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f6564276-7a09-4213-9b2c-5d00b2522577")
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 127 76.2 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09bcb57e-0110-47fa-86ea-62612766122d")
+		(property "Reference" "#PWR037"
+			(at 120.65 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 123.19 76.1999 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 127 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 127 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "83d66431-51d8-41d8-a969-2b90a205ca5b")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR037")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 165.1 76.2 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0f4884df-ede5-48a1-a610-f20079edfcb7")
+		(property "Reference" "#PWR039"
+			(at 171.45 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 168.91 76.2001 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 165.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 165.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7ef9e64f-6fe8-42de-83bc-71855e2d0ab2")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR039")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_02x20_Counter_Clockwise")
+		(at 144.78 99.06 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "39546a5f-88f9-4b95-a884-1c228458f851")
+		(property "Reference" "J10"
+			(at 146.05 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Conn_02x20_Counter_Clockwise"
+			(at 146.05 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 144.78 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 144.78 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, double row, 02x20, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 144.78 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "13"
+			(uuid "153e82bd-012e-4fbd-a8a1-bf051c9638a2")
+		)
+		(pin "31"
+			(uuid "91ac683b-0a90-45ec-97b7-dc3f2ee66f35")
+		)
+		(pin "8"
+			(uuid "5aa7a067-7dc2-409e-bb62-a89e1c05704a")
+		)
+		(pin "12"
+			(uuid "2f375445-a50e-4419-bfe2-3d63135da292")
+		)
+		(pin "16"
+			(uuid "97772a1a-7cfa-434d-873c-d452dc9f0c21")
+		)
+		(pin "14"
+			(uuid "bfaec227-9119-4689-90a6-6c40c8863564")
+		)
+		(pin "15"
+			(uuid "db579d6e-6629-42a9-b024-ecbfde32b28a")
+		)
+		(pin "7"
+			(uuid "7a4ca739-57fb-4a54-89d9-5a4cf07d14bd")
+		)
+		(pin "21"
+			(uuid "6c9bc019-7808-4916-aeb3-4c6fb74082f9")
+		)
+		(pin "5"
+			(uuid "0baa3b5e-146e-4b81-9eb1-27211d8d55a1")
+		)
+		(pin "18"
+			(uuid "2e97e30d-d186-4f6b-8bca-4ca7e66cbbad")
+		)
+		(pin "29"
+			(uuid "833ab21d-9c51-4671-85ec-552bec5bc645")
+		)
+		(pin "11"
+			(uuid "31650536-88f5-4052-a129-562a09dc99a1")
+		)
+		(pin "32"
+			(uuid "51e1a88d-473a-4c07-8165-f1b15141f5cf")
+		)
+		(pin "37"
+			(uuid "88be4267-5da6-458f-bbe2-623019b01d9e")
+		)
+		(pin "17"
+			(uuid "bd979c80-b986-412f-a9ee-3e16691d65ae")
+		)
+		(pin "27"
+			(uuid "37e56cef-cf55-42af-86a2-bdb768e2edf7")
+		)
+		(pin "33"
+			(uuid "25d617e9-0f8f-4247-8edb-7568c905d62d")
+		)
+		(pin "22"
+			(uuid "a2f7ceba-be60-409d-a2a4-cdf58afe94d6")
+		)
+		(pin "38"
+			(uuid "4b7c60a6-fc2e-48ac-8502-3a36582ed158")
+		)
+		(pin "23"
+			(uuid "487effd8-f964-4ffd-9f67-3b7bfc807a78")
+		)
+		(pin "4"
+			(uuid "2ffcbeec-2cb4-4072-81a9-48a2db749a44")
+		)
+		(pin "25"
+			(uuid "676e407b-8839-4a16-b2fb-6b5248b86450")
+		)
+		(pin "19"
+			(uuid "2495252d-8d58-4ff4-acf9-0d427bc20eea")
+		)
+		(pin "10"
+			(uuid "586a7e3a-7a5c-4bf3-a54d-53f901076ef1")
+		)
+		(pin "36"
+			(uuid "7943e18b-35ff-4303-8778-7275eadb734c")
+		)
+		(pin "30"
+			(uuid "240e1fca-d4fa-4c19-95c1-28b6a90bcc78")
+		)
+		(pin "3"
+			(uuid "5c6bf994-0e29-45e2-9afc-9d56418930c9")
+		)
+		(pin "28"
+			(uuid "ffc249e3-7a3b-4b56-b837-b22e663116fc")
+		)
+		(pin "40"
+			(uuid "868d2110-248a-4f6f-a77d-131ddda92a6b")
+		)
+		(pin "39"
+			(uuid "2e008923-78c0-4b5f-8224-4c24f144e191")
+		)
+		(pin "20"
+			(uuid "adb5961d-95a8-495b-a458-57bccadae707")
+		)
+		(pin "24"
+			(uuid "b9754450-90c0-4bb6-a787-e47f1b747683")
+		)
+		(pin "34"
+			(uuid "f801c50d-6100-464e-842c-011e19eb59de")
+		)
+		(pin "2"
+			(uuid "b6ab18e8-fd65-4031-90c7-ed6df4042d78")
+		)
+		(pin "6"
+			(uuid "78baf1d2-e0e7-4500-a190-d08a64df9c08")
+		)
+		(pin "1"
+			(uuid "6acda7a0-6c40-4832-be38-dbf2a4121f9c")
+		)
+		(pin "26"
+			(uuid "48fa7ad2-e924-41f1-8e7c-5b8d31a9e673")
+		)
+		(pin "9"
+			(uuid "4b337902-3edb-49a8-bbad-70e04a6cf395")
+		)
+		(pin "35"
+			(uuid "b32415e9-8150-43ed-8434-bc93df0acf86")
+		)
+		(instances
+			(project ""
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "J10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 127 124.46 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "caecc2fb-4a73-4fa9-a539-27813fd882d1")
+		(property "Reference" "#PWR038"
+			(at 120.65 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 123.19 124.4599 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 127 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 127 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eaf680f0-06cd-491f-ac40-7172e9918226")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR038")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 127 99.06 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d9489389-8351-4e80-8961-ff14d932b1e9")
+		(property "Reference" "#PWR041"
+			(at 120.65 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 123.19 99.0599 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 127 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 127 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "25f836c0-1083-4d0e-83ca-69a4eb7475c7")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR041")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 165.1 99.06 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f78d766f-8914-4410-8636-25f09ae72227")
+		(property "Reference" "#PWR042"
+			(at 171.45 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 168.91 99.0601 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 165.1 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 165.1 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6374eb30-9d84-4404-81f5-31e36a9f7f40")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR042")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 165.1 124.46 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fade12aa-0b7d-4f5a-853f-12615e37468a")
+		(property "Reference" "#PWR040"
+			(at 171.45 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 168.91 124.4601 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 165.1 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 165.1 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b3f37cd0-e30e-478e-814a-600c62b8657e")
+		)
+		(instances
+			(project "eps"
+				(path "/9e0ae2e7-d4be-41b4-8312-0d2aceea2180/b219b5f3-4d87-4e00-9626-11450f76e9f7"
+					(reference "#PWR040")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/eps/hardware/stm32l4.kicad_sch
+++ b/eps/hardware/stm32l4.kicad_sch
@@ -5427,8 +5427,248 @@
 		(uuid "fe36af97-4f83-4114-bd07-4d437f8742f2")
 	)
 	(no_connect
+		(at 77.47 76.2)
+		(uuid "0083aec3-ae7d-49e6-8559-581f6e16e949")
+	)
+	(no_connect
+		(at 212.09 137.16)
+		(uuid "0155ee52-21fd-4290-82f8-f130ca3fcc5e")
+	)
+	(no_connect
+		(at 110.49 137.16)
+		(uuid "04794478-366a-4789-b806-3afe65c16497")
+	)
+	(no_connect
+		(at 95.25 76.2)
+		(uuid "055f39bf-9c52-4a91-9bb9-2229bc12fcf5")
+	)
+	(no_connect
+		(at 110.49 76.2)
+		(uuid "05faa122-3c9a-4755-9fcc-c8a1be6167a3")
+	)
+	(no_connect
+		(at 158.75 76.2)
+		(uuid "06bccaeb-b3c1-476f-8735-516379a558a1")
+	)
+	(no_connect
+		(at 135.89 76.2)
+		(uuid "0ef2af2a-2a95-4191-ab02-5ad0bb4ecb17")
+	)
+	(no_connect
+		(at 128.27 76.2)
+		(uuid "12f81fbc-46b9-487f-8a27-262834f2663e")
+	)
+	(no_connect
+		(at 118.11 76.2)
+		(uuid "16c5219f-4e18-479d-b9f2-a40fa3c77335")
+	)
+	(no_connect
+		(at 69.85 76.2)
+		(uuid "2b4f3cde-8fe3-48b9-b9d1-55d579be314f")
+	)
+	(no_connect
+		(at 92.71 137.16)
+		(uuid "2f86fa94-0c38-4ff3-8c0f-e41b36128f24")
+	)
+	(no_connect
+		(at 74.93 76.2)
+		(uuid "32dc396e-4500-493b-b615-7b2df23f40fe")
+	)
+	(no_connect
 		(at 238.76 29.21)
 		(uuid "38213f08-7289-44b1-b12c-77c2ee70e2fc")
+	)
+	(no_connect
+		(at 143.51 76.2)
+		(uuid "39c7f425-6724-48d7-9ca5-e581f632ec16")
+	)
+	(no_connect
+		(at 82.55 76.2)
+		(uuid "3c8e67eb-2c75-42db-8552-746226a48d3c")
+	)
+	(no_connect
+		(at 207.01 137.16)
+		(uuid "427e16ef-1d29-42a3-a920-d3f4adeefed9")
+	)
+	(no_connect
+		(at 179.07 76.2)
+		(uuid "4573100c-1a74-4a6a-a740-0586a1d0c5a6")
+	)
+	(no_connect
+		(at 72.39 76.2)
+		(uuid "50bc44c3-16c4-49d3-8035-d784e91f67df")
+	)
+	(no_connect
+		(at 214.63 137.16)
+		(uuid "534fffae-b858-4796-85fa-f24006d0a864")
+	)
+	(no_connect
+		(at 156.21 76.2)
+		(uuid "5734dc7c-903a-4d2e-a742-8d92cfa6660a")
+	)
+	(no_connect
+		(at 161.29 76.2)
+		(uuid "5c9213aa-bc08-4cc3-8fbe-e6ef04b54fbd")
+	)
+	(no_connect
+		(at 186.69 76.2)
+		(uuid "5e40432e-d828-4a40-88cf-50d08dfa3741")
+	)
+	(no_connect
+		(at 148.59 76.2)
+		(uuid "66d54d4a-3108-4546-b76b-f35dceae1a63")
+	)
+	(no_connect
+		(at 128.27 137.16)
+		(uuid "6e4b889a-3ae5-488f-9225-31c1f8a17c34")
+	)
+	(no_connect
+		(at 146.05 76.2)
+		(uuid "705f4de0-5b07-4826-908f-d1af4589fe71")
+	)
+	(no_connect
+		(at 90.17 137.16)
+		(uuid "708029b0-6014-411a-bf1f-6a9cb2a59fd6")
+	)
+	(no_connect
+		(at 80.01 76.2)
+		(uuid "743d0a92-2a30-45de-9a31-aedea12029fc")
+	)
+	(no_connect
+		(at 168.91 76.2)
+		(uuid "7a251840-1328-4cf8-b6ac-4206315eff72")
+	)
+	(no_connect
+		(at 123.19 137.16)
+		(uuid "7aab0170-7706-4782-b04b-e0f342e82713")
+	)
+	(no_connect
+		(at 113.03 76.2)
+		(uuid "7bc58575-15d1-45d1-ad19-e26e9c084abc")
+	)
+	(no_connect
+		(at 105.41 76.2)
+		(uuid "7e2c04f4-6004-41ca-abda-bfe0518de2fe")
+	)
+	(no_connect
+		(at 153.67 76.2)
+		(uuid "7e590f76-c1ab-469a-b6ce-0a2bf13c990b")
+	)
+	(no_connect
+		(at 118.11 137.16)
+		(uuid "81cbc19b-6990-41fc-8417-3f62922c4c77")
+	)
+	(no_connect
+		(at 171.45 76.2)
+		(uuid "884ae4c5-89e9-4f0b-83b2-49049827d1ec")
+	)
+	(no_connect
+		(at 209.55 137.16)
+		(uuid "8cb5542c-6bab-4061-b73b-353a331a912f")
+	)
+	(no_connect
+		(at 130.81 76.2)
+		(uuid "8e0789e3-ae78-4e9e-95ff-5d6867994ff8")
+	)
+	(no_connect
+		(at 85.09 76.2)
+		(uuid "8e0ddebb-fcf2-47b4-aaea-b0831ce3f163")
+	)
+	(no_connect
+		(at 105.41 137.16)
+		(uuid "9af60e5a-5125-4c2b-9bd9-3e948141e71e")
+	)
+	(no_connect
+		(at 67.31 76.2)
+		(uuid "a32f7f69-a7b0-4e5a-877a-09e115c4caa4")
+	)
+	(no_connect
+		(at 120.65 137.16)
+		(uuid "a84a97fe-a3b8-4416-be0e-e2c3efb0e448")
+	)
+	(no_connect
+		(at 133.35 76.2)
+		(uuid "b10132c6-2807-4561-9120-7f0e86983ea8")
+	)
+	(no_connect
+		(at 102.87 137.16)
+		(uuid "b5ff760d-3208-4cd9-9ed9-1e9118fab439")
+	)
+	(no_connect
+		(at 97.79 76.2)
+		(uuid "c19d98c1-dd28-4359-b87c-d4ceaff819af")
+	)
+	(no_connect
+		(at 123.19 76.2)
+		(uuid "c3efad59-e609-431a-b027-1ea75be73699")
+	)
+	(no_connect
+		(at 107.95 137.16)
+		(uuid "c4568c89-829d-48ef-9f47-d60bec9e00ea")
+	)
+	(no_connect
+		(at 173.99 76.2)
+		(uuid "c7681938-8eed-4a07-ace4-f2c4e074bada")
+	)
+	(no_connect
+		(at 184.15 76.2)
+		(uuid "cbc794f8-7715-49ec-b38b-d6ef470b2d9f")
+	)
+	(no_connect
+		(at 181.61 76.2)
+		(uuid "cdf63632-da4d-40e9-bfd1-3e9a56a7a852")
+	)
+	(no_connect
+		(at 125.73 76.2)
+		(uuid "d1195b22-e68f-4f85-b58b-a716e4495b5e")
+	)
+	(no_connect
+		(at 87.63 76.2)
+		(uuid "d59c6359-6a03-4da7-846a-feccc49c2fe4")
+	)
+	(no_connect
+		(at 140.97 76.2)
+		(uuid "dab1d837-3db7-4899-97db-944d275da82e")
+	)
+	(no_connect
+		(at 100.33 137.16)
+		(uuid "e0e0d8ee-1e19-47c6-92d0-5c7a89437368")
+	)
+	(no_connect
+		(at 90.17 76.2)
+		(uuid "e2f825ff-483d-429a-aee2-f8bd3fc0bccd")
+	)
+	(no_connect
+		(at 125.73 137.16)
+		(uuid "e42699dd-5a5f-4945-8ba6-1abbaeebe79d")
+	)
+	(no_connect
+		(at 97.79 137.16)
+		(uuid "e6e3eecc-1a40-45a1-86b9-b3e7ad213bdf")
+	)
+	(no_connect
+		(at 95.25 137.16)
+		(uuid "e717bab9-26a8-4ffd-9896-2102a0e7d769")
+	)
+	(no_connect
+		(at 92.71 76.2)
+		(uuid "eaeb5a6e-afb8-49b9-b1aa-ac897ca85f12")
+	)
+	(no_connect
+		(at 120.65 76.2)
+		(uuid "ed9f275d-c0dc-464d-9000-ebf38d868415")
+	)
+	(no_connect
+		(at 176.53 76.2)
+		(uuid "ee4dd86c-0649-42ec-8ac9-aa38d1c8ff20")
+	)
+	(no_connect
+		(at 115.57 76.2)
+		(uuid "f0c4ad31-946c-47b2-9416-f64dc927c99a")
+	)
+	(no_connect
+		(at 138.43 76.2)
+		(uuid "f2545e73-9bfe-47cd-94ba-0ded8a23e264")
 	)
 	(wire
 		(pts
@@ -5542,6 +5782,16 @@
 	)
 	(wire
 		(pts
+			(xy 163.83 68.58) (xy 163.83 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10a1f020-6fa6-438e-ac07-0f5463da66ee")
+	)
+	(wire
+		(pts
 			(xy 238.76 24.13) (xy 248.92 24.13)
 		)
 		(stroke
@@ -5559,6 +5809,16 @@
 			(type default)
 		)
 		(uuid "1594a6af-21d1-4cf5-938a-ff4fa763ef87")
+	)
+	(wire
+		(pts
+			(xy 184.15 137.16) (xy 184.15 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1951da42-9a2f-46d8-8404-33917079a2a9")
 	)
 	(wire
 		(pts
@@ -5622,6 +5882,16 @@
 	)
 	(wire
 		(pts
+			(xy 189.23 137.16) (xy 189.23 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2020992b-9c80-42c0-8aab-cda1c3dbff4c")
+	)
+	(wire
+		(pts
 			(xy 194.31 69.85) (xy 194.31 63.5)
 		)
 		(stroke
@@ -5629,6 +5899,26 @@
 			(type default)
 		)
 		(uuid "21991f85-d638-43c6-b99a-a97322437c32")
+	)
+	(wire
+		(pts
+			(xy 158.75 137.16) (xy 158.75 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "222a02c2-37b3-493b-88cf-95fa9e0e3578")
+	)
+	(wire
+		(pts
+			(xy 179.07 137.16) (xy 179.07 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "231128c3-9906-41e6-9a79-5f1a903476a3")
 	)
 	(wire
 		(pts
@@ -5672,6 +5962,16 @@
 	)
 	(wire
 		(pts
+			(xy 199.39 137.16) (xy 199.39 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "280bdc40-1bac-4b20-9e7a-46e0314c89b8")
+	)
+	(wire
+		(pts
 			(xy 101.6 175.26) (xy 101.6 179.07)
 		)
 		(stroke
@@ -5709,6 +6009,16 @@
 			(type default)
 		)
 		(uuid "306b4ec5-69de-4ceb-9235-c0cabb57f1e3")
+	)
+	(wire
+		(pts
+			(xy 204.47 137.16) (xy 204.47 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "315f724f-d44f-4f66-9819-9da480638957")
 	)
 	(wire
 		(pts
@@ -5752,6 +6062,16 @@
 	)
 	(wire
 		(pts
+			(xy 140.97 137.16) (xy 140.97 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3633dd30-a2e2-4dc2-8c01-9d7910912353")
+	)
+	(wire
+		(pts
 			(xy 54.61 93.98) (xy 54.61 91.44)
 		)
 		(stroke
@@ -5792,6 +6112,16 @@
 	)
 	(wire
 		(pts
+			(xy 143.51 137.16) (xy 143.51 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f563027-f8eb-4605-9176-5f0414814754")
+	)
+	(wire
+		(pts
 			(xy 135.89 24.13) (xy 147.32 24.13)
 		)
 		(stroke
@@ -5802,6 +6132,26 @@
 	)
 	(wire
 		(pts
+			(xy 171.45 137.16) (xy 171.45 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "446a446a-63e7-48dc-b6ae-fd9bf1dd1c85")
+	)
+	(wire
+		(pts
+			(xy 151.13 137.16) (xy 151.13 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45be0fa1-c9ef-4c21-b39c-f178257d97ea")
+	)
+	(wire
+		(pts
 			(xy 44.45 24.13) (xy 44.45 26.67)
 		)
 		(stroke
@@ -5809,6 +6159,16 @@
 			(type default)
 		)
 		(uuid "46134500-047a-4380-b5c5-fd2c8f124103")
+	)
+	(wire
+		(pts
+			(xy 168.91 137.16) (xy 168.91 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "464ddd40-b99b-4bf8-808c-aaaaf0295c11")
 	)
 	(wire
 		(pts
@@ -5972,6 +6332,26 @@
 	)
 	(wire
 		(pts
+			(xy 115.57 137.16) (xy 115.57 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b710630-528c-409e-909d-ebf1e833084f")
+	)
+	(wire
+		(pts
+			(xy 176.53 137.16) (xy 176.53 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5bbd92a7-9e76-4bd8-ab7a-bbbc4d36efce")
+	)
+	(wire
+		(pts
 			(xy 27.94 147.32) (xy 31.75 147.32)
 		)
 		(stroke
@@ -5989,6 +6369,16 @@
 			(type default)
 		)
 		(uuid "5c0e63ac-2531-4b74-8509-ac99545bf157")
+	)
+	(wire
+		(pts
+			(xy 186.69 137.16) (xy 186.69 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c23c5ff-4345-4467-875a-c4e6e93ad525")
 	)
 	(wire
 		(pts
@@ -6029,6 +6419,16 @@
 			(type default)
 		)
 		(uuid "60481ad7-1048-4067-9554-1d780af495e8")
+	)
+	(wire
+		(pts
+			(xy 113.03 137.16) (xy 113.03 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "61178e82-d86a-444c-9ca1-b03f011ee1d3")
 	)
 	(wire
 		(pts
@@ -6079,6 +6479,26 @@
 			(type default)
 		)
 		(uuid "678f0981-45ee-47c7-9ddf-34f3dacf559b")
+	)
+	(wire
+		(pts
+			(xy 166.37 68.58) (xy 166.37 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "67cbfc13-881f-4d4c-88ec-3bb3b0b7a09f")
+	)
+	(wire
+		(pts
+			(xy 163.83 137.16) (xy 163.83 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68ba0398-6a1f-4027-aa1e-77c5be55a1cc")
 	)
 	(wire
 		(pts
@@ -6139,6 +6559,16 @@
 			(type default)
 		)
 		(uuid "7376967c-fbe3-454f-a313-824329a035ca")
+	)
+	(wire
+		(pts
+			(xy 166.37 137.16) (xy 166.37 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "742fb53c-f3fe-41e8-8bf2-78722ee6794c")
 	)
 	(wire
 		(pts
@@ -6392,6 +6822,16 @@
 	)
 	(wire
 		(pts
+			(xy 196.85 137.16) (xy 196.85 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "90dc9b31-6bd9-4f03-9a96-5356bf8421b1")
+	)
+	(wire
+		(pts
 			(xy 54.61 104.14) (xy 54.61 106.68)
 		)
 		(stroke
@@ -6409,6 +6849,16 @@
 			(type default)
 		)
 		(uuid "943d6ac8-1653-413d-ae65-37431ecc269d")
+	)
+	(wire
+		(pts
+			(xy 138.43 137.16) (xy 138.43 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9651a52e-5538-4d22-9418-9c308721211e")
 	)
 	(wire
 		(pts
@@ -6612,6 +7062,26 @@
 	)
 	(wire
 		(pts
+			(xy 181.61 137.16) (xy 181.61 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "acc12069-13d4-4424-b758-1adbd1bf6bed")
+	)
+	(wire
+		(pts
+			(xy 156.21 137.16) (xy 156.21 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adbda1b7-4df3-47c4-81f1-7ba020d8f9c2")
+	)
+	(wire
+		(pts
 			(xy 165.1 24.13) (xy 165.1 26.67)
 		)
 		(stroke
@@ -6632,6 +7102,16 @@
 	)
 	(wire
 		(pts
+			(xy 153.67 137.16) (xy 153.67 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2ca4e61-e218-4732-8146-0521df4130d6")
+	)
+	(wire
+		(pts
 			(xy 190.5 34.29) (xy 190.5 36.83)
 		)
 		(stroke
@@ -6639,6 +7119,16 @@
 			(type default)
 		)
 		(uuid "b3a65b14-cd5d-41ec-9c56-b8aacbefdfba")
+	)
+	(wire
+		(pts
+			(xy 201.93 137.16) (xy 201.93 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f041fe-6dff-4b43-8e07-2ba0bc57e170")
 	)
 	(wire
 		(pts
@@ -6679,6 +7169,16 @@
 			(type default)
 		)
 		(uuid "be5da7f8-ac4b-421d-882e-62b499dd6065")
+	)
+	(wire
+		(pts
+			(xy 133.35 137.16) (xy 133.35 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c12d2a13-ffa7-4c87-a4f7-780621a94dec")
 	)
 	(wire
 		(pts
@@ -6782,6 +7282,16 @@
 	)
 	(wire
 		(pts
+			(xy 146.05 137.16) (xy 146.05 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbafd727-c166-4ddc-b403-0468894a4da5")
+	)
+	(wire
+		(pts
 			(xy 125.73 34.29) (xy 135.89 34.29)
 		)
 		(stroke
@@ -6812,6 +7322,16 @@
 	)
 	(wire
 		(pts
+			(xy 135.89 137.16) (xy 135.89 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce53cf2b-ebf5-4db3-b8ab-8704d4894f52")
+	)
+	(wire
+		(pts
 			(xy 125.73 31.75) (xy 125.73 34.29)
 		)
 		(stroke
@@ -6839,6 +7359,16 @@
 			(type default)
 		)
 		(uuid "cfec872d-d859-44fb-8b5e-54c256afc3d9")
+	)
+	(wire
+		(pts
+			(xy 194.31 137.16) (xy 194.31 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1ee63a0-1d01-44ea-8b7f-d8905403c1e7")
 	)
 	(wire
 		(pts
@@ -6882,6 +7412,16 @@
 	)
 	(wire
 		(pts
+			(xy 148.59 137.16) (xy 148.59 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da59422d-d1b0-4ab3-b84d-16185cf609cd")
+	)
+	(wire
+		(pts
 			(xy 57.15 99.06) (xy 54.61 99.06)
 		)
 		(stroke
@@ -6899,6 +7439,16 @@
 			(type default)
 		)
 		(uuid "db645505-036e-41fd-9275-d1f4697b9424")
+	)
+	(wire
+		(pts
+			(xy 191.77 137.16) (xy 191.77 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db7aaba5-998d-48be-a186-5d24fb45ec6f")
 	)
 	(wire
 		(pts
@@ -7089,6 +7639,16 @@
 			(type default)
 		)
 		(uuid "f36b91ce-1213-44b5-b8f6-bbc98ca64214")
+	)
+	(wire
+		(pts
+			(xy 161.29 137.16) (xy 161.29 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4e0c125-7ee8-49a2-83b3-2bcb15f85140")
 	)
 	(wire
 		(pts
@@ -7320,6 +7880,28 @@
 		)
 		(uuid "d19cec93-1c6c-4d1a-ab42-90a30778a04e")
 	)
+	(hierarchical_label "U_WARN1"
+		(shape input)
+		(at 156.21 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0477b8ac-388e-4889-b1f7-461f2a71b323")
+	)
+	(hierarchical_label "EPS_OBC_RESET"
+		(shape output)
+		(at 201.93 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "05074cf6-5352-4cfd-b721-5b85b44c205c")
+	)
 	(hierarchical_label "RAIL_6_ON"
 		(shape bidirectional)
 		(at 222.25 68.58 90)
@@ -7330,6 +7912,17 @@
 			(justify left)
 		)
 		(uuid "0aa5f54f-1dd4-4492-80a7-66df1e721de6")
+	)
+	(hierarchical_label "REG_2_SDA"
+		(shape bidirectional)
+		(at 189.23 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0f5ed525-399d-4ce1-b9b8-6f32e5d1879f")
 	)
 	(hierarchical_label "RESET"
 		(shape input)
@@ -7342,6 +7935,17 @@
 		)
 		(uuid "117f2a6e-5689-47f5-9f8e-86951e3760af")
 	)
+	(hierarchical_label "REG_2_SCL"
+		(shape output)
+		(at 191.77 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "23afad89-efd2-4af7-9304-2ffcb9ba4159")
+	)
 	(hierarchical_label "VREF+"
 		(shape output)
 		(at 52.07 170.18 180)
@@ -7353,6 +7957,50 @@
 		)
 		(uuid "240de3f1-f263-4e70-bee8-d0a28f63e3e5")
 	)
+	(hierarchical_label "SYSTEM_UART_AUX_TX"
+		(shape output)
+		(at 163.83 68.58 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2c6c6d00-129a-4fdb-8ca7-4f7d15143f8d")
+	)
+	(hierarchical_label "C2_ALERT"
+		(shape input)
+		(at 153.67 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2dea6c51-1f21-45f9-b549-99c2e124522b")
+	)
+	(hierarchical_label "OBC_HEARTBEAT"
+		(shape input)
+		(at 204.47 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "38ff4490-369f-4647-9240-8a1cf7236401")
+	)
+	(hierarchical_label "C1_DVCC"
+		(shape output)
+		(at 140.97 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3b8805a5-4261-4bed-8212-dff24b36d3af")
+	)
 	(hierarchical_label "RAIL_3_ON"
 		(shape bidirectional)
 		(at 207.01 68.58 90)
@@ -7363,6 +8011,72 @@
 			(justify left)
 		)
 		(uuid "433ecba1-59d0-4b32-bf4c-5e26012e286e")
+	)
+	(hierarchical_label "SYSTEM_UART_MAIN_TX"
+		(shape output)
+		(at 113.03 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "449f33d5-07f5-48a0-8079-0bfa2df09c5c")
+	)
+	(hierarchical_label "U_WARN2"
+		(shape input)
+		(at 158.75 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4ba2f828-20a2-4506-852f-92f4dd772f3c")
+	)
+	(hierarchical_label "U_STAT1"
+		(shape input)
+		(at 161.29 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4bd73e3e-0246-4a17-a1b7-5f9e431acc09")
+	)
+	(hierarchical_label "WDI"
+		(shape output)
+		(at 199.39 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4c0ff7f9-3ae8-4b6d-80b2-b82554fabca9")
+	)
+	(hierarchical_label "C1_ALERT"
+		(shape input)
+		(at 143.51 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4e539656-aef1-46d3-a98e-720bd55908b0")
+	)
+	(hierarchical_label "D_WARN1"
+		(shape input)
+		(at 166.37 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "50f30000-92d5-4fa7-9eac-be79e5a9d84d")
 	)
 	(hierarchical_label "RAIL_1_RST"
 		(shape output)
@@ -7397,6 +8111,17 @@
 		)
 		(uuid "656e188d-55bc-443c-804a-43410186e77a")
 	)
+	(hierarchical_label "REG_1_SCL"
+		(shape output)
+		(at 184.15 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "65b29a00-2630-401b-b283-13e67d33247f")
+	)
 	(hierarchical_label "RAIL_7_RST"
 		(shape output)
 		(at 229.87 68.58 90)
@@ -7407,6 +8132,17 @@
 			(justify left)
 		)
 		(uuid "702100d1-6c1f-4143-a8e9-819af9f86cf5")
+	)
+	(hierarchical_label "C2_DVCC"
+		(shape output)
+		(at 151.13 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "74b93985-b8a2-4bac-9265-1661ab9e5026")
 	)
 	(hierarchical_label "RAIL_8_ON"
 		(shape bidirectional)
@@ -7430,6 +8166,39 @@
 		)
 		(uuid "787a3a88-d7ee-4d58-b2d6-d9a2c482dd6e")
 	)
+	(hierarchical_label "C2_SDA"
+		(shape bidirectional)
+		(at 148.59 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "80805eb9-139e-4e5e-9145-5bfd736f78a6")
+	)
+	(hierarchical_label "PGOOD"
+		(shape input)
+		(at 133.35 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8310b216-2fa4-4025-a582-c0182cf15110")
+	)
+	(hierarchical_label "SET0"
+		(shape output)
+		(at 194.31 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8711e615-30bd-4bd8-a1fd-63956ed25237")
+	)
 	(hierarchical_label "VDD"
 		(shape input)
 		(at 20.32 24.13 180)
@@ -7440,6 +8209,17 @@
 			(justify right)
 		)
 		(uuid "8a25e40c-7689-41b5-8797-9a4ea6122038")
+	)
+	(hierarchical_label "D_STAT1"
+		(shape input)
+		(at 171.45 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "985b8f08-4f95-44c9-bc54-fb939bdece4a")
 	)
 	(hierarchical_label "RAIL_5_ON"
 		(shape bidirectional)
@@ -7463,6 +8243,39 @@
 		)
 		(uuid "9c1c23c4-88fd-424a-abb5-15be6427ef7c")
 	)
+	(hierarchical_label "D_STAT2"
+		(shape input)
+		(at 176.53 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "abc0284c-0077-44fa-9fd3-cf8e5d21661d")
+	)
+	(hierarchical_label "C1_SCL"
+		(shape output)
+		(at 135.89 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b68896ce-bfa5-4b58-8b83-d2eb29021d6c")
+	)
+	(hierarchical_label "SET1"
+		(shape output)
+		(at 196.85 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b8ea9aa3-df14-4363-be7d-6f13f28eb50b")
+	)
 	(hierarchical_label "RAIL_5_RST"
 		(shape output)
 		(at 219.71 68.58 90)
@@ -7484,6 +8297,39 @@
 			(justify left)
 		)
 		(uuid "be110af8-5002-4ed8-9360-540f2fd861ca")
+	)
+	(hierarchical_label "D_WARN2"
+		(shape input)
+		(at 168.91 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c356529c-1475-4e07-9e0e-d8d444319f02")
+	)
+	(hierarchical_label "C2_SCL"
+		(shape output)
+		(at 146.05 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c6b0c6cd-b7a7-4f52-9bbc-df226bd91f76")
+	)
+	(hierarchical_label "REG_1_ALT"
+		(shape input)
+		(at 179.07 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d63530d2-9909-4256-9041-a2378ef7271b")
 	)
 	(hierarchical_label "RAIL_2_RST"
 		(shape output)
@@ -7507,6 +8353,39 @@
 		)
 		(uuid "db5302a3-902f-4aef-a965-1d37bae57e4e")
 	)
+	(hierarchical_label "REG_2_ALT"
+		(shape input)
+		(at 186.69 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ddf27c3d-4de2-49d9-aecf-6843234c096c")
+	)
+	(hierarchical_label "C1_SDA"
+		(shape bidirectional)
+		(at 138.43 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e3e7f7cf-5953-4818-adad-17619a10f5f3")
+	)
+	(hierarchical_label "SYSTEM_UART_AUX_RX"
+		(shape input)
+		(at 166.37 68.58 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f6594b0a-669f-4fb9-bf6e-06faaf0db696")
+	)
 	(hierarchical_label "RAIL_8_RST"
 		(shape output)
 		(at 234.95 68.58 90)
@@ -7518,6 +8397,28 @@
 		)
 		(uuid "f6cecf6f-1827-4b56-a399-c80e0b641e42")
 	)
+	(hierarchical_label "SYSTEM_UART_MAIN_RX"
+		(shape input)
+		(at 115.57 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f71eef2f-b76c-45b7-961e-790a0a447f4d")
+	)
+	(hierarchical_label "REG_1_SDA"
+		(shape bidirectional)
+		(at 181.61 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f7cb75f0-afbf-48e7-adb8-b3ac0af98e61")
+	)
 	(hierarchical_label "RAIL_1_ON"
 		(shape bidirectional)
 		(at 196.85 68.58 90)
@@ -7528,6 +8429,17 @@
 			(justify left)
 		)
 		(uuid "f9168001-fff4-4b33-b38c-dbf7ccdd2b50")
+	)
+	(hierarchical_label "U_STAT2"
+		(shape input)
+		(at 163.83 144.78 270)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fcf370da-8032-490c-a73b-6931dba8679e")
 	)
 	(symbol
 		(lib_id "power:GND")


### PR DESCRIPTION
These changes do the following:

- Hook up all I2C and other status pins to the STM32
- Add a 2x20 inter-board connector
- Create the inter-board connector pinout
- Add primary & auxiliary UART Tx/Rx lines for OBC <-> EPS communication
- Expose UART heartbeat & reset line for the EPS to have ultimate power-cycling control over the OBC if it locks up
- Polish main sheet
- Fix some ERC errors