### PR TITLE
Finish I2C HAL driver

### DIFF
--- a/eps/firmware/bsp/mcu/Src/i2c.c
+++ b/eps/firmware/bsp/mcu/Src/i2c.c
@@ -1,21 +1,21 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file    i2c.c
-  * @brief   This file provides code for the configuration
-  *          of the I2C instances.
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2026 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    i2c.c
+ * @brief   This file provides code for the configuration
+ *          of the I2C instances.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2026 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "i2c.h"
@@ -30,400 +30,400 @@ I2C_HandleTypeDef hi2c3;
 I2C_HandleTypeDef hi2c4;
 
 /* I2C1 init function */
-void MX_I2C1_Init(void)
-{
+void MX_I2C1_Init(void) {
 
-  /* USER CODE BEGIN I2C1_Init 0 */
+    /* USER CODE BEGIN I2C1_Init 0 */
 
-  /* USER CODE END I2C1_Init 0 */
+    /* USER CODE END I2C1_Init 0 */
 
-  /* USER CODE BEGIN I2C1_Init 1 */
+    /* USER CODE BEGIN I2C1_Init 1 */
 
-  /* USER CODE END I2C1_Init 1 */
-  hi2c1.Instance = I2C1;
-  hi2c1.Init.Timing = 0x10D19CE4;
-  hi2c1.Init.OwnAddress1 = 0;
-  hi2c1.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-  hi2c1.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-  hi2c1.Init.OwnAddress2 = 0;
-  hi2c1.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-  hi2c1.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-  hi2c1.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-  if (HAL_I2C_Init(&hi2c1) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /* USER CODE END I2C1_Init 1 */
+    hi2c1.Instance = I2C1;
+    hi2c1.Init.Timing = 0x10D19CE4;
+    hi2c1.Init.OwnAddress1 = 0;
+    hi2c1.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c1.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c1.Init.OwnAddress2 = 0;
+    hi2c1.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c1.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c1.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c1) != HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Analogue filter
-  */
-  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c1, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c1, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Digital filter
-  */
-  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c1, 0) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN I2C1_Init 2 */
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c1, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN I2C1_Init 2 */
 
-  /* USER CODE END I2C1_Init 2 */
-
+    /* USER CODE END I2C1_Init 2 */
 }
 /* I2C2 init function */
-void MX_I2C2_Init(void)
-{
+void MX_I2C2_Init(void) {
 
-  /* USER CODE BEGIN I2C2_Init 0 */
+    /* USER CODE BEGIN I2C2_Init 0 */
 
-  /* USER CODE END I2C2_Init 0 */
+    /* USER CODE END I2C2_Init 0 */
 
-  /* USER CODE BEGIN I2C2_Init 1 */
+    /* USER CODE BEGIN I2C2_Init 1 */
 
-  /* USER CODE END I2C2_Init 1 */
-  hi2c2.Instance = I2C2;
-  hi2c2.Init.Timing = 0x10D19CE4;
-  hi2c2.Init.OwnAddress1 = 0;
-  hi2c2.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-  hi2c2.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-  hi2c2.Init.OwnAddress2 = 0;
-  hi2c2.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-  hi2c2.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-  hi2c2.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-  if (HAL_I2C_Init(&hi2c2) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /* USER CODE END I2C2_Init 1 */
+    hi2c2.Instance = I2C2;
+    hi2c2.Init.Timing = 0x10D19CE4;
+    hi2c2.Init.OwnAddress1 = 0;
+    hi2c2.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c2.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c2.Init.OwnAddress2 = 0;
+    hi2c2.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c2.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c2.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c2) != HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Analogue filter
-  */
-  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Digital filter
-  */
-  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN I2C2_Init 2 */
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN I2C2_Init 2 */
 
-  /* USER CODE END I2C2_Init 2 */
-
+    /* USER CODE END I2C2_Init 2 */
 }
 /* I2C3 init function */
-void MX_I2C3_Init(void)
-{
+void MX_I2C3_Init(void) {
 
-  /* USER CODE BEGIN I2C3_Init 0 */
+    /* USER CODE BEGIN I2C3_Init 0 */
 
-  /* USER CODE END I2C3_Init 0 */
+    /* USER CODE END I2C3_Init 0 */
 
-  /* USER CODE BEGIN I2C3_Init 1 */
+    /* USER CODE BEGIN I2C3_Init 1 */
 
-  /* USER CODE END I2C3_Init 1 */
-  hi2c3.Instance = I2C3;
-  hi2c3.Init.Timing = 0x10D19CE4;
-  hi2c3.Init.OwnAddress1 = 0;
-  hi2c3.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-  hi2c3.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-  hi2c3.Init.OwnAddress2 = 0;
-  hi2c3.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-  hi2c3.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-  hi2c3.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-  if (HAL_I2C_Init(&hi2c3) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /* USER CODE END I2C3_Init 1 */
+    hi2c3.Instance = I2C3;
+    hi2c3.Init.Timing = 0x10D19CE4;
+    hi2c3.Init.OwnAddress1 = 0;
+    hi2c3.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c3.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c3.Init.OwnAddress2 = 0;
+    hi2c3.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c3.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c3.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c3) != HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Analogue filter
-  */
-  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c3, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c3, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Digital filter
-  */
-  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c3, 0) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN I2C3_Init 2 */
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c3, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN I2C3_Init 2 */
 
-  /* USER CODE END I2C3_Init 2 */
-
+    /* USER CODE END I2C3_Init 2 */
 }
 /* I2C4 init function */
-void MX_I2C4_Init(void)
-{
+void MX_I2C4_Init(void) {
 
-  /* USER CODE BEGIN I2C4_Init 0 */
+    /* USER CODE BEGIN I2C4_Init 0 */
 
-  /* USER CODE END I2C4_Init 0 */
+    /* USER CODE END I2C4_Init 0 */
 
-  /* USER CODE BEGIN I2C4_Init 1 */
+    /* USER CODE BEGIN I2C4_Init 1 */
 
-  /* USER CODE END I2C4_Init 1 */
-  hi2c4.Instance = I2C4;
-  hi2c4.Init.Timing = 0x10D19CE4;
-  hi2c4.Init.OwnAddress1 = 0;
-  hi2c4.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-  hi2c4.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-  hi2c4.Init.OwnAddress2 = 0;
-  hi2c4.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-  hi2c4.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-  hi2c4.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-  if (HAL_I2C_Init(&hi2c4) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /* USER CODE END I2C4_Init 1 */
+    hi2c4.Instance = I2C4;
+    hi2c4.Init.Timing = 0x10D19CE4;
+    hi2c4.Init.OwnAddress1 = 0;
+    hi2c4.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c4.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c4.Init.OwnAddress2 = 0;
+    hi2c4.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c4.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c4.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c4) != HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Analogue filter
-  */
-  if (HAL_I2CEx_ConfigAnalogFilter(&hi2c4, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
-  {
-    Error_Handler();
-  }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c4, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
 
-  /** Configure Digital filter
-  */
-  if (HAL_I2CEx_ConfigDigitalFilter(&hi2c4, 0) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN I2C4_Init 2 */
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c4, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    /* USER CODE BEGIN I2C4_Init 2 */
 
-  /* USER CODE END I2C4_Init 2 */
-
+    /* USER CODE END I2C4_Init 2 */
 }
 
-void HAL_I2C_MspInit(I2C_HandleTypeDef* i2cHandle)
-{
+void HAL_I2C_MspInit(I2C_HandleTypeDef *i2cHandle) {
 
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
-  if(i2cHandle->Instance==I2C1)
-  {
-  /* USER CODE BEGIN I2C1_MspInit 0 */
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
+    if (i2cHandle->Instance == I2C1) {
+        /* USER CODE BEGIN I2C1_MspInit 0 */
 
-  /* USER CODE END I2C1_MspInit 0 */
+        /* USER CODE END I2C1_MspInit 0 */
 
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C1;
-    PeriphClkInit.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
-    {
-      Error_Handler();
+        /** Initializes the peripherals clock
+         */
+        PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C1;
+        PeriphClkInit.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+            Error_Handler();
+        }
+
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**I2C1 GPIO Configuration
+        PB6     ------> I2C1_SCL
+        PB7     ------> I2C1_SDA
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        /* I2C1 clock enable */
+        __HAL_RCC_I2C1_CLK_ENABLE();
+
+        /* I2C1 interrupt Init */
+        HAL_NVIC_SetPriority(I2C1_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C1_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C1_ER_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C1_ER_IRQn);
+        /* USER CODE BEGIN I2C1_MspInit 1 */
+
+        /* USER CODE END I2C1_MspInit 1 */
+    } else if (i2cHandle->Instance == I2C2) {
+        /* USER CODE BEGIN I2C2_MspInit 0 */
+
+        /* USER CODE END I2C2_MspInit 0 */
+
+        /** Initializes the peripherals clock
+         */
+        PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C2;
+        PeriphClkInit.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+            Error_Handler();
+        }
+
+        __HAL_RCC_GPIOF_CLK_ENABLE();
+        /**I2C2 GPIO Configuration
+        PF0     ------> I2C2_SDA
+        PF1     ------> I2C2_SCL
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+        /* I2C2 clock enable */
+        __HAL_RCC_I2C2_CLK_ENABLE();
+
+        /* I2C2 interrupt Init */
+        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
+        /* USER CODE BEGIN I2C2_MspInit 1 */
+
+        /* USER CODE END I2C2_MspInit 1 */
+    } else if (i2cHandle->Instance == I2C3) {
+        /* USER CODE BEGIN I2C3_MspInit 0 */
+
+        /* USER CODE END I2C3_MspInit 0 */
+
+        /** Initializes the peripherals clock
+         */
+        PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C3;
+        PeriphClkInit.I2c3ClockSelection = RCC_I2C3CLKSOURCE_PCLK1;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+            Error_Handler();
+        }
+
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**I2C3 GPIO Configuration
+        PC0     ------> I2C3_SCL
+        PC1     ------> I2C3_SDA
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C3;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        /* I2C3 clock enable */
+        __HAL_RCC_I2C3_CLK_ENABLE();
+
+        /* I2C3 interrupt Init */
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C3_ER_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
+        /* USER CODE BEGIN I2C3_MspInit 1 */
+
+        /* USER CODE END I2C3_MspInit 1 */
+    } else if (i2cHandle->Instance == I2C4) {
+        /* USER CODE BEGIN I2C4_MspInit 0 */
+
+        /* USER CODE END I2C4_MspInit 0 */
+
+        /** Initializes the peripherals clock
+         */
+        PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C4;
+        PeriphClkInit.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PCLK1;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+            Error_Handler();
+        }
+
+        __HAL_RCC_GPIOF_CLK_ENABLE();
+        /**I2C4 GPIO Configuration
+        PF14     ------> I2C4_SCL
+        PF15     ------> I2C4_SDA
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C4;
+        HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+        /* I2C4 clock enable */
+        __HAL_RCC_I2C4_CLK_ENABLE();
+
+        /* I2C4 interrupt Init */
+        HAL_NVIC_SetPriority(I2C4_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C4_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C4_ER_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C4_ER_IRQn);
+        /* USER CODE BEGIN I2C4_MspInit 1 */
+
+        /* USER CODE END I2C4_MspInit 1 */
     }
-
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    /**I2C1 GPIO Configuration
-    PB6     ------> I2C1_SCL
-    PB7     ------> I2C1_SDA
-    */
-    GPIO_InitStruct.Pin = GPIO_PIN_6|GPIO_PIN_7;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
-    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-    /* I2C1 clock enable */
-    __HAL_RCC_I2C1_CLK_ENABLE();
-  /* USER CODE BEGIN I2C1_MspInit 1 */
-
-  /* USER CODE END I2C1_MspInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C2)
-  {
-  /* USER CODE BEGIN I2C2_MspInit 0 */
-
-  /* USER CODE END I2C2_MspInit 0 */
-
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C2;
-    PeriphClkInit.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
-    {
-      Error_Handler();
-    }
-
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    /**I2C2 GPIO Configuration
-    PF0     ------> I2C2_SDA
-    PF1     ------> I2C2_SCL
-    */
-    GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
-    HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-    /* I2C2 clock enable */
-    __HAL_RCC_I2C2_CLK_ENABLE();
-  /* USER CODE BEGIN I2C2_MspInit 1 */
-
-  /* USER CODE END I2C2_MspInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C3)
-  {
-  /* USER CODE BEGIN I2C3_MspInit 0 */
-
-  /* USER CODE END I2C3_MspInit 0 */
-
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C3;
-    PeriphClkInit.I2c3ClockSelection = RCC_I2C3CLKSOURCE_PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
-    {
-      Error_Handler();
-    }
-
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    /**I2C3 GPIO Configuration
-    PC0     ------> I2C3_SCL
-    PC1     ------> I2C3_SDA
-    */
-    GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF4_I2C3;
-    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-    /* I2C3 clock enable */
-    __HAL_RCC_I2C3_CLK_ENABLE();
-  /* USER CODE BEGIN I2C3_MspInit 1 */
-
-  /* USER CODE END I2C3_MspInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C4)
-  {
-  /* USER CODE BEGIN I2C4_MspInit 0 */
-
-  /* USER CODE END I2C4_MspInit 0 */
-
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_I2C4;
-    PeriphClkInit.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
-    {
-      Error_Handler();
-    }
-
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    /**I2C4 GPIO Configuration
-    PF14     ------> I2C4_SCL
-    PF15     ------> I2C4_SDA
-    */
-    GPIO_InitStruct.Pin = GPIO_PIN_14|GPIO_PIN_15;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF4_I2C4;
-    HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-    /* I2C4 clock enable */
-    __HAL_RCC_I2C4_CLK_ENABLE();
-  /* USER CODE BEGIN I2C4_MspInit 1 */
-
-  /* USER CODE END I2C4_MspInit 1 */
-  }
 }
 
-void HAL_I2C_MspDeInit(I2C_HandleTypeDef* i2cHandle)
-{
+void HAL_I2C_MspDeInit(I2C_HandleTypeDef *i2cHandle) {
 
-  if(i2cHandle->Instance==I2C1)
-  {
-  /* USER CODE BEGIN I2C1_MspDeInit 0 */
+    if (i2cHandle->Instance == I2C1) {
+        /* USER CODE BEGIN I2C1_MspDeInit 0 */
 
-  /* USER CODE END I2C1_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_I2C1_CLK_DISABLE();
+        /* USER CODE END I2C1_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C1_CLK_DISABLE();
 
-    /**I2C1 GPIO Configuration
-    PB6     ------> I2C1_SCL
-    PB7     ------> I2C1_SDA
-    */
-    HAL_GPIO_DeInit(GPIOB, GPIO_PIN_6);
+        /**I2C1 GPIO Configuration
+        PB6     ------> I2C1_SCL
+        PB7     ------> I2C1_SDA
+        */
+        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_6);
 
-    HAL_GPIO_DeInit(GPIOB, GPIO_PIN_7);
+        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_7);
 
-  /* USER CODE BEGIN I2C1_MspDeInit 1 */
+        /* I2C1 interrupt Deinit */
+        HAL_NVIC_DisableIRQ(I2C1_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C1_ER_IRQn);
+        /* USER CODE BEGIN I2C1_MspDeInit 1 */
 
-  /* USER CODE END I2C1_MspDeInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C2)
-  {
-  /* USER CODE BEGIN I2C2_MspDeInit 0 */
+        /* USER CODE END I2C1_MspDeInit 1 */
+    } else if (i2cHandle->Instance == I2C2) {
+        /* USER CODE BEGIN I2C2_MspDeInit 0 */
 
-  /* USER CODE END I2C2_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_I2C2_CLK_DISABLE();
+        /* USER CODE END I2C2_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C2_CLK_DISABLE();
 
-    /**I2C2 GPIO Configuration
-    PF0     ------> I2C2_SDA
-    PF1     ------> I2C2_SCL
-    */
-    HAL_GPIO_DeInit(GPIOF, GPIO_PIN_0);
+        /**I2C2 GPIO Configuration
+        PF0     ------> I2C2_SDA
+        PF1     ------> I2C2_SCL
+        */
+        HAL_GPIO_DeInit(GPIOF, GPIO_PIN_0);
 
-    HAL_GPIO_DeInit(GPIOF, GPIO_PIN_1);
+        HAL_GPIO_DeInit(GPIOF, GPIO_PIN_1);
 
-  /* USER CODE BEGIN I2C2_MspDeInit 1 */
+        /* I2C2 interrupt Deinit */
+        HAL_NVIC_DisableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C2_ER_IRQn);
+        /* USER CODE BEGIN I2C2_MspDeInit 1 */
 
-  /* USER CODE END I2C2_MspDeInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C3)
-  {
-  /* USER CODE BEGIN I2C3_MspDeInit 0 */
+        /* USER CODE END I2C2_MspDeInit 1 */
+    } else if (i2cHandle->Instance == I2C3) {
+        /* USER CODE BEGIN I2C3_MspDeInit 0 */
 
-  /* USER CODE END I2C3_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_I2C3_CLK_DISABLE();
+        /* USER CODE END I2C3_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C3_CLK_DISABLE();
 
-    /**I2C3 GPIO Configuration
-    PC0     ------> I2C3_SCL
-    PC1     ------> I2C3_SDA
-    */
-    HAL_GPIO_DeInit(GPIOC, GPIO_PIN_0);
+        /**I2C3 GPIO Configuration
+        PC0     ------> I2C3_SCL
+        PC1     ------> I2C3_SDA
+        */
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_0);
 
-    HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1);
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1);
 
-  /* USER CODE BEGIN I2C3_MspDeInit 1 */
+        /* I2C3 interrupt Deinit */
+        HAL_NVIC_DisableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C3_ER_IRQn);
+        /* USER CODE BEGIN I2C3_MspDeInit 1 */
 
-  /* USER CODE END I2C3_MspDeInit 1 */
-  }
-  else if(i2cHandle->Instance==I2C4)
-  {
-  /* USER CODE BEGIN I2C4_MspDeInit 0 */
+        /* USER CODE END I2C3_MspDeInit 1 */
+    } else if (i2cHandle->Instance == I2C4) {
+        /* USER CODE BEGIN I2C4_MspDeInit 0 */
 
-  /* USER CODE END I2C4_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_I2C4_CLK_DISABLE();
+        /* USER CODE END I2C4_MspDeInit 0 */
+        /* Peripheral clock disable */
+        __HAL_RCC_I2C4_CLK_DISABLE();
 
-    /**I2C4 GPIO Configuration
-    PF14     ------> I2C4_SCL
-    PF15     ------> I2C4_SDA
-    */
-    HAL_GPIO_DeInit(GPIOF, GPIO_PIN_14);
+        /**I2C4 GPIO Configuration
+        PF14     ------> I2C4_SCL
+        PF15     ------> I2C4_SDA
+        */
+        HAL_GPIO_DeInit(GPIOF, GPIO_PIN_14);
 
-    HAL_GPIO_DeInit(GPIOF, GPIO_PIN_15);
+        HAL_GPIO_DeInit(GPIOF, GPIO_PIN_15);
 
-  /* USER CODE BEGIN I2C4_MspDeInit 1 */
+        /* I2C4 interrupt Deinit */
+        HAL_NVIC_DisableIRQ(I2C4_EV_IRQn);
+        HAL_NVIC_DisableIRQ(I2C4_ER_IRQn);
+        /* USER CODE BEGIN I2C4_MspDeInit 1 */
 
-  /* USER CODE END I2C4_MspDeInit 1 */
-  }
+        /* USER CODE END I2C4_MspDeInit 1 */
+    }
 }
 
 /* USER CODE BEGIN 1 */

--- a/eps/firmware/bsp/mcu/Src/stm32l4xx_it.c
+++ b/eps/firmware/bsp/mcu/Src/stm32l4xx_it.c
@@ -19,7 +19,9 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l4xx_it.h"
+#include "hal_i2c.h"
 #include "hal_uart.h"
+#include "i2c.h"
 #include "main.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -264,6 +266,114 @@ void UART4_IRQHandler(void) {
     /* USER CODE BEGIN UART4_IRQn 1 */
 
     /* USER CODE END UART4_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 event interrupt.
+ */
+void I2C1_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C1_EV_IRQn 0 */
+
+    /* USER CODE END I2C1_EV_IRQn 0 */
+    hal_i2c_isr_handler(I2C_BUS_1);
+
+    /* USER CODE BEGIN I2C1_EV_IRQn 1 */
+
+    /* USER CODE END I2C1_EV_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 error interrupt.
+ */
+void I2C1_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C1_ER_IRQn 0 */
+
+    /* USER CODE END I2C1_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c1);
+    /* USER CODE BEGIN I2C1_ER_IRQn 1 */
+
+    /* USER CODE END I2C1_ER_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 event interrupt.
+ */
+void I2C2_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C2_EV_IRQn 0 */
+
+    /* USER CODE END I2C2_EV_IRQn 0 */
+    hal_i2c_isr_handler(I2C_BUS_2);
+
+    /* USER CODE BEGIN I2C2_EV_IRQn 1 */
+
+    /* USER CODE END I2C2_EV_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 error interrupt.
+ */
+void I2C2_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C2_ER_IRQn 0 */
+
+    /* USER CODE END I2C2_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c2);
+    /* USER CODE BEGIN I2C2_ER_IRQn 1 */
+
+    /* USER CODE END I2C2_ER_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 event interrupt.
+ */
+void I2C3_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C3_EV_IRQn 0 */
+
+    /* USER CODE END I2C3_EV_IRQn 0 */
+    hal_i2c_isr_handler(I2C_BUS_3);
+
+    /* USER CODE BEGIN I2C3_EV_IRQn 1 */
+
+    /* USER CODE END I2C3_EV_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 error interrupt.
+ */
+void I2C3_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C3_ER_IRQn 0 */
+
+    /* USER CODE END I2C3_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c3);
+    /* USER CODE BEGIN I2C3_ER_IRQn 1 */
+
+    /* USER CODE END I2C3_ER_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 event interrupt.
+ */
+void I2C4_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C4_EV_IRQn 0 */
+
+    /* USER CODE END I2C4_EV_IRQn 0 */
+    hal_i2c_isr_handler(I2C_BUS_4);
+
+    /* USER CODE BEGIN I2C4_EV_IRQn 1 */
+
+    /* USER CODE END I2C4_EV_IRQn 1 */
+}
+
+/**
+ * @brief This function handles I2C1 error interrupt.
+ */
+void I2C4_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C4_ER_IRQn 0 */
+
+    /* USER CODE END I2C4_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c4);
+    /* USER CODE BEGIN I2C4_ER_IRQn 1 */
+
+    /* USER CODE END I2C4_ER_IRQn 1 */
 }
 
 /* USER CODE END 1 */

--- a/eps/firmware/config/eps_config.h
+++ b/eps/firmware/config/eps_config.h
@@ -8,6 +8,8 @@
 
 #define SERVICE_COUNT 8
 
+#define I2C_TIMING_BITFIELD 0x10D19CE4
+
 typedef enum { // these rails correspond to the hardware rails
     RAIL_OBC,
     RAIL_RADIO,

--- a/eps/firmware/hal/hal_i2c.c
+++ b/eps/firmware/hal/hal_i2c.c
@@ -1,0 +1,83 @@
+/**
+ * @file hal_i2c.c
+ * @brief I2C hardware abstraction implementation
+ *
+ * This implementation allows reading and writing to I2C devices
+ */
+
+#include "hal_i2c.h"
+#include "osusat/ring_buffer.h"
+#include "stm32l4xx_hal_i2c.h"
+#include "stm32l4xx_hal_uart.h"
+#include <stdint.h>
+
+/**
+ * @struct i2c_bus_state_t
+ * @brief Internal state for a single I2C bus
+ */
+typedef struct {
+    I2C_HandleTypeDef *hi2c; /**< STM32 HAL I2C handle */
+
+    osusat_ring_buffer_t rx_ring;        /**< RX ring buffer */
+    uint8_t rx_storage[I2C_RX_CAPACITY]; /**< Storage for RX ring buffer */
+
+    i2c_rx_callback_t rx_callback; /**< User RX callback */
+    void *rx_callback_ctx;         /**< User callback context */
+    uint8_t rx_byte;               /**< Single byte for interrupt RX */
+
+    i2c_error_cb_t error_callback; /**< User error callback hook */
+    void *error_callback_ctx;      /**< Error context */
+
+    bool initialized; /**< Init flag */
+} i2c_bus_state_t;
+
+static i2c_bus_state_t g_bus_state[I2C_BUS_COUNT];
+
+extern I2C_HandleTypeDef hi2c1;
+extern I2C_HandleTypeDef hi2c2;
+extern I2C_HandleTypeDef hi2c3;
+extern I2C_HandleTypeDef hi2c4;
+
+/**
+ * @brief Map i2c_bus_t to STM32 HAL I2C handle
+ */
+static I2C_HandleTypeDef *get_hal_handle(i2c_bus_t bus) {
+    switch (bus) {
+    case I2C_BUS_1:
+        return &hi2c1;
+    case I2C_BUS_2:
+        return &hi2c2;
+    case I2C_BUS_3:
+        return &hi2c3;
+    case I2C_BUS_4:
+        return &hi2c4;
+    default:
+        return NULL;
+    }
+}
+
+/**
+ * @brief Start reception for a single byte (used by interrupt-driven RX)
+ */
+static void start_rx_interrupt(i2c_bus_t bus) {
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    // start receiving single byte in interrupt mode
+    HAL_UART_Receive_IT(state->hi2c, &state->rx_byte, 1);
+}
+
+void hal_i2c_init(i2c_bus_t bus) {
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    state->hi2c = get_hal_handle(bus);
+    if (state->hi2c == NULL) {
+        return;
+    }
+
+    osusat_ring_buffer_init(&state->rx_ring, state->rx_storage, I2C_RX_CAPACITY,
+                            true);
+}

--- a/eps/firmware/hal/hal_i2c.c
+++ b/eps/firmware/hal/hal_i2c.c
@@ -6,9 +6,9 @@
  */
 
 #include "hal_i2c.h"
-#include "osusat/ring_buffer.h"
+#include "eps_config.h"
+#include "stm32l4xx_hal.h"
 #include "stm32l4xx_hal_i2c.h"
-#include "stm32l4xx_hal_uart.h"
 #include <stdint.h>
 
 /**
@@ -18,16 +18,20 @@
 typedef struct {
     I2C_HandleTypeDef *hi2c; /**< STM32 HAL I2C handle */
 
-    osusat_ring_buffer_t rx_ring;        /**< RX ring buffer */
-    uint8_t rx_storage[I2C_RX_CAPACITY]; /**< Storage for RX ring buffer */
+    uint8_t rx_buffer[I2C_RX_CAPACITY]; /**< Buffer for interrupt RX */
+    uint8_t *rx_user_buffer;            /**< User destination buffer */
+    uint16_t rx_len;                    /**< Number of requested bytes */
 
-    i2c_rx_callback_t rx_callback; /**< User RX callback */
-    void *rx_callback_ctx;         /**< User callback context */
-    uint8_t rx_byte;               /**< Single byte for interrupt RX */
+    i2c_rx_callback_t rx_callback; /**< Current reception RX callback */
+    void *rx_callback_ctx;         /**< Current reception context */
 
-    i2c_error_cb_t error_callback; /**< User error callback hook */
+    i2c_tx_callback_t tx_callback; /**< Current transaction TX callback */
+    void *tx_callback_ctx;         /**< Current transaction context */
+
+    i2c_error_cb_t error_callback; /**< Curretn user error callback hook */
     void *error_callback_ctx;      /**< Error context */
 
+    bool busy;        /**< Whether the line is busy */
     bool initialized; /**< Init flag */
 } i2c_bus_state_t;
 
@@ -57,13 +61,83 @@ static I2C_HandleTypeDef *get_hal_handle(i2c_bus_t bus) {
 }
 
 /**
- * @brief Start reception for a single byte (used by interrupt-driven RX)
+ * @brief Start reception (used by interrupt-driven RX)
  */
-static void start_rx_interrupt(i2c_bus_t bus) {
+static i2c_status_t start_rx_interrupt(i2c_bus_t bus, uint8_t addr,
+                                       uint16_t len) {
     i2c_bus_state_t *state = &g_bus_state[bus];
 
-    // start receiving single byte in interrupt mode
-    HAL_UART_Receive_IT(state->hi2c, &state->rx_byte, 1);
+    if (state->busy) {
+        return I2C_BUSY;
+    }
+
+    state->rx_len = len;
+    state->busy = true;
+
+    HAL_StatusTypeDef status = HAL_I2C_Master_Receive_IT(state->hi2c, addr << 1,
+                                                         state->rx_buffer, len);
+
+    return (status == HAL_OK) ? I2C_OK : I2C_ERROR;
+}
+
+/**
+ * @brief Start reception (used by interrupt-driven RX)
+ */
+static i2c_status_t start_rx_mem_interrupt(i2c_bus_t bus, uint8_t addr,
+                                           uint8_t reg, uint16_t len) {
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (state->busy) {
+        return I2C_BUSY;
+    }
+
+    state->rx_len = len;
+    state->busy = true;
+
+    HAL_StatusTypeDef status = HAL_I2C_Mem_Read_IT(
+        state->hi2c, addr, reg, I2C_MEMADD_SIZE_8BIT, state->rx_buffer, len);
+
+    return (status == HAL_OK) ? I2C_OK : I2C_ERROR;
+}
+
+/**
+ * @brief Start write transmission
+ */
+static i2c_status_t start_tx_interrupt(i2c_bus_t bus, uint8_t addr,
+                                       const uint8_t *data, uint16_t len) {
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (state->busy) {
+        return I2C_BUSY;
+    }
+
+    state->busy = true;
+
+    HAL_StatusTypeDef status = HAL_I2C_Master_Transmit_IT(
+        state->hi2c, addr << 1, (uint8_t *)data, len);
+
+    return (status == HAL_OK) ? I2C_OK : I2C_ERROR;
+}
+
+/**
+ * @brief Start memory write
+ */
+static i2c_status_t start_tx_mem_interrupt(i2c_bus_t bus, uint8_t addr,
+                                           uint8_t reg, const uint8_t *data,
+                                           uint16_t len) {
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (state->busy) {
+        return I2C_BUSY;
+    }
+
+    state->busy = true;
+
+    HAL_StatusTypeDef status =
+        HAL_I2C_Mem_Write_IT(state->hi2c, addr << 1, reg, I2C_MEMADD_SIZE_8BIT,
+                             (uint8_t *)data, len);
+
+    return (status == HAL_OK) ? I2C_OK : I2C_ERROR;
 }
 
 void hal_i2c_init(i2c_bus_t bus) {
@@ -78,6 +152,273 @@ void hal_i2c_init(i2c_bus_t bus) {
         return;
     }
 
-    osusat_ring_buffer_init(&state->rx_ring, state->rx_storage, I2C_RX_CAPACITY,
-                            true);
+    state->hi2c->Instance = I2C1;
+    state->hi2c->Init.Timing = I2C_TIMING_BITFIELD;
+    state->hi2c->Init.OwnAddress1 = 0;
+    state->hi2c->Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    state->hi2c->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    state->hi2c->Init.OwnAddress2 = 0;
+    state->hi2c->Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    state->hi2c->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    state->hi2c->Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+
+    if (HAL_I2C_Init(state->hi2c) != HAL_OK) {
+        return;
+    }
+
+    state->initialized = true;
+}
+
+i2c_error_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
+                         uint16_t len, i2c_rx_callback_t cb,
+                         i2c_error_cb_t err_cb, void *ctx) {
+    if (bus >= I2C_BUS_COUNT || data == NULL || len == 0) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (!state->initialized) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    if (state->busy) {
+        return I2C_HAL_ERR_BUSY;
+    }
+
+    if (len > I2C_RX_CAPACITY) {
+        return I2C_HAL_ERR_TOO_LARGE;
+    }
+
+    state->rx_callback = cb;
+    state->rx_callback_ctx = ctx;
+    state->error_callback = err_cb;
+    state->error_callback_ctx = ctx;
+    state->rx_user_buffer = data;
+
+    for (uint16_t i = 0; i < len; i++) {
+        state->rx_buffer[i] = 0;
+    }
+
+    i2c_status_t status = start_rx_interrupt(bus, addr, len);
+    if (status != I2C_OK) {
+        return I2C_HAL_ERR_BUSY;
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+i2c_error_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                             uint8_t *data, uint16_t len, i2c_rx_callback_t cb,
+                             i2c_error_cb_t err_cb, void *ctx) {
+    if (bus >= I2C_BUS_COUNT || data == NULL || len == 0) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (!state->initialized) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    if (state->busy) {
+        return I2C_HAL_ERR_BUSY;
+    }
+
+    if (len > I2C_RX_CAPACITY) {
+        return I2C_HAL_ERR_TOO_LARGE;
+    }
+
+    state->rx_callback = cb;
+    state->rx_callback_ctx = ctx;
+    state->error_callback = err_cb;
+    state->error_callback_ctx = ctx;
+    state->rx_user_buffer = data;
+
+    for (uint16_t i = 0; i < len; i++) {
+        state->rx_buffer[i] = 0;
+    }
+
+    i2c_status_t status = start_rx_mem_interrupt(bus, addr, reg, len);
+    if (status != I2C_OK) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+i2c_error_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
+                          uint16_t len, i2c_tx_callback_t cb,
+                          i2c_error_cb_t err_cb, void *ctx) {
+    if (bus >= I2C_BUS_COUNT || data == NULL || len == 0) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (!state->initialized) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    if (state->busy) {
+        return I2C_HAL_ERR_BUSY;
+    }
+
+    state->tx_callback = cb;
+    state->tx_callback_ctx = ctx;
+    state->error_callback = err_cb;
+    state->error_callback_ctx = ctx;
+
+    i2c_status_t status = start_tx_interrupt(bus, addr, data, len);
+    if (status != I2C_OK) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+i2c_error_t hal_i2c_mem_write(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                              uint8_t *data, uint16_t len, i2c_tx_callback_t cb,
+                              i2c_error_cb_t err_cb, void *ctx) {
+    if (bus >= I2C_BUS_COUNT || data == NULL || len == 0) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    if (!state->initialized) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    if (state->busy) {
+        return I2C_HAL_ERR_BUSY;
+    }
+
+    state->tx_callback = cb;
+    state->tx_callback_ctx = ctx;
+    state->error_callback = err_cb;
+    state->error_callback_ctx = ctx;
+
+    i2c_status_t status = start_tx_mem_interrupt(bus, addr, reg, data, len);
+    if (status != I2C_OK) {
+        return I2C_HAL_ERR_UNKNOWN;
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+void hal_i2c_register_error_callback(i2c_bus_t bus, i2c_error_cb_t cb,
+                                     void *ctx) {
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    state->error_callback = cb;
+    state->error_callback_ctx = ctx;
+}
+
+void hal_i2c_isr_handler(i2c_bus_t bus) {
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+    if (!state->initialized) {
+        return;
+    }
+
+    HAL_I2C_EV_IRQHandler(state->hi2c);
+}
+
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    i2c_bus_t bus;
+    for (bus = 0; bus < I2C_BUS_COUNT; bus++) {
+        if (g_bus_state[bus].hi2c == hi2c) {
+            break;
+        }
+    }
+
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+
+    for (uint16_t i = 0; i < state->rx_len; i++) {
+        state->rx_user_buffer[i] = state->rx_buffer[i];
+    }
+
+    state->busy = false;
+
+    if (state->rx_callback) {
+        state->rx_callback(bus, state->rx_callback_ctx);
+    }
+}
+
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    i2c_bus_t bus;
+    for (bus = 0; bus < I2C_BUS_COUNT; bus++) {
+        if (g_bus_state[bus].hi2c == hi2c) {
+            break;
+        }
+    }
+
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+    state->busy = false;
+
+    if (state->tx_callback) {
+        state->tx_callback(bus, state->tx_callback_ctx);
+    }
+}
+
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    HAL_I2C_MasterRxCpltCallback(hi2c);
+}
+
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    HAL_I2C_MasterTxCpltCallback(hi2c);
+}
+
+static i2c_error_t hal_error_to_i2c_error(uint32_t hal_err) {
+    if (hal_err & HAL_I2C_ERROR_BERR)
+        return I2C_HAL_ERR_BUS;
+    if (hal_err & HAL_I2C_ERROR_ARLO)
+        return I2C_HAL_ERR_ARBITRATION;
+    if (hal_err & HAL_I2C_ERROR_AF)
+        return I2C_HAL_ERR_NACK;
+    if (hal_err & HAL_I2C_ERROR_OVR)
+        return I2C_HAL_ERR_OVERRUN;
+    if (hal_err & HAL_I2C_ERROR_TIMEOUT)
+        return I2C_HAL_ERR_TIMEOUT;
+    if (hal_err & HAL_I2C_ERROR_DMA)
+        return I2C_HAL_ERR_UNKNOWN;
+    return I2C_HAL_ERR_UNKNOWN;
+}
+
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c) {
+    i2c_bus_t bus;
+    for (bus = 0; bus < I2C_BUS_COUNT; bus++) {
+        if (g_bus_state[bus].hi2c == hi2c) {
+            break;
+        }
+    }
+
+    if (bus >= I2C_BUS_COUNT) {
+        return;
+    }
+
+    i2c_bus_state_t *state = &g_bus_state[bus];
+    state->busy = false;
+
+    i2c_error_t err = hal_error_to_i2c_error(hi2c->ErrorCode);
+
+    if (state->error_callback) {
+        state->error_callback(bus, err, state->error_callback_ctx);
+    }
 }

--- a/eps/firmware/hal/hal_i2c.h
+++ b/eps/firmware/hal/hal_i2c.h
@@ -22,8 +22,23 @@
  * @defgroup i2c_types Types
  * @ingroup i2c
  * @brief Types used by the I2C driver.
+ *
  * @{
  */
+
+#define I2C_RX_CAPACITY 128
+
+/**
+ * @enum i2c_bus_t
+ * @brief Identifiers for the available I2C busses
+ */
+typedef enum {
+    I2C_BUS_1 = 1,
+    I2C_BUS_2,
+    I2C_BUS_3,
+    I2C_BUS_4,
+    I2C_BUS_COUNT
+} i2c_bus_t;
 
 /**
  * @enum i2c_status_t
@@ -37,10 +52,31 @@ typedef enum {
 } i2c_status_t;
 
 /**
- * @enum i2c_bus_t
- * @brief Identifiers for the available I2C busses
+ * @enum i2c_error_t
+ * @brief Errors that could occur during I2C HAL use
  */
-typedef enum { I2C_BUS_1 = 1, I2C_BUS_2, I2C_BUS_3, I2C_BUS_4 } i2c_bus_t;
+typedef enum {
+    I2C_HAL_ERR_UNKNOWN,
+} i2c_error_t;
+
+/**
+ * @brief Callback for UART RX events.
+ *
+ * Executed outside the ISR by the UART service or event bus.
+ *
+ * @param port   The UART that received data.
+ * @param ctx    Caller-specified context pointer.
+ */
+typedef void (*i2c_rx_callback_t)(i2c_bus_t bus, void *ctx);
+
+/**
+ * @brief Callback function type upon UART errors.
+ *
+ * @param[in] port   UART port index
+ * @param[in] err    The UART error that occurred
+ * @param[in] ctx    The error context
+ */
+typedef void (*i2c_error_cb_t)(i2c_bus_t bus, i2c_error_t err, void *ctx);
 
 /** @} */ // end i2c_types
 
@@ -51,6 +87,8 @@ typedef enum { I2C_BUS_1 = 1, I2C_BUS_2, I2C_BUS_3, I2C_BUS_4 } i2c_bus_t;
  *
  * @{
  */
+
+void hal_i2c_init(i2c_bus_t bus);
 
 /**
  * @brief Write data to an I2C device.
@@ -91,6 +129,14 @@ i2c_status_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
  */
 i2c_status_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
                               uint8_t *data, uint16_t len);
+
+/**
+ * @brief ISR entry point for I2C interrupts
+ * Should be called from MCU's I2C_IRQHandler()
+ *
+ * @param[in] The I2C bus
+ */
+void hal_i2c_isr_handler(i2c_bus_t bus);
 
 /** @} */ // end i2c_api
 /** @} */ // end i2c

--- a/eps/firmware/hal/hal_i2c.h
+++ b/eps/firmware/hal/hal_i2c.h
@@ -48,6 +48,7 @@ typedef enum {
     I2C_OK = 0,  /**< Operation successful */
     I2C_ERROR,   /**< Generic error */
     I2C_TIMEOUT, /**< Bus timeout */
+    I2C_BUSY,    /**< The line is busy */
     I2C_NACK     /**< Device not acknowledged */
 } i2c_status_t;
 
@@ -56,24 +57,38 @@ typedef enum {
  * @brief Errors that could occur during I2C HAL use
  */
 typedef enum {
+    I2C_HAL_ERR_BUS,
+    I2C_HAL_ERR_ARBITRATION,
+    I2C_HAL_ERR_NACK,
+    I2C_HAL_ERR_OVERRUN,
+    I2C_HAL_ERR_TIMEOUT,
     I2C_HAL_ERR_UNKNOWN,
+    I2C_HAL_ERR_BUSY,
+    I2C_HAL_ERR_TOO_LARGE,
+    I2C_HAL_ERR_NONE,
 } i2c_error_t;
 
 /**
- * @brief Callback for UART RX events.
+ * @brief Callback for I2C RX events.
  *
- * Executed outside the ISR by the UART service or event bus.
- *
- * @param port   The UART that received data.
+ * @param port   The I2C bus that received data.
  * @param ctx    Caller-specified context pointer.
  */
 typedef void (*i2c_rx_callback_t)(i2c_bus_t bus, void *ctx);
 
 /**
- * @brief Callback function type upon UART errors.
+ * @brief Callback for I2C TX events.
  *
- * @param[in] port   UART port index
- * @param[in] err    The UART error that occurred
+ * @param port   The I2C bus that received data.
+ * @param ctx    Caller-specified context pointer.
+ */
+typedef void (*i2c_tx_callback_t)(i2c_bus_t bus, void *ctx);
+
+/**
+ * @brief Callback function type upon I2C errors.
+ *
+ * @param[in] port   I2C bus index
+ * @param[in] err    The I2C error that occurred
  * @param[in] ctx    The error context
  */
 typedef void (*i2c_error_cb_t)(i2c_bus_t bus, i2c_error_t err, void *ctx);
@@ -97,11 +112,33 @@ void hal_i2c_init(i2c_bus_t bus);
  * @param[in] addr    The 7-bit device address.
  * @param[in] data    Pointer to the data buffer to transmit.
  * @param[in] len     Number of bytes to write.
+ * @param[in] cb      The callback to fire upon completion
+ * @param[in] err_cb  The callback to fire upon an error occurring
+ * @param[in] ctx     The context to provide to the callback upon firing
  *
  * @return i2c_status_t Status code.
  */
-i2c_status_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
-                           uint16_t len);
+i2c_error_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
+                          uint16_t len, i2c_tx_callback_t cb,
+                          i2c_error_cb_t err_cb, void *ctx);
+
+/**
+ * @brief Write to a specific register on the I2C device
+ *
+ * @param[in] bus     The I2C bus identifier.
+ * @param[in] addr    The 7-bit device address.
+ * @param[in] reg     The register address to write to.
+ * @param[out] data   Pointer to the buffer containing data to be transmitted.
+ * @param[in] len     Number of bytes to write.
+ * @param[in] cb      The callback to fire upon completion
+ * @param[in] err_cb  The callback to fire upon an error occurring
+ * @param[in] ctx     The context to provide to the callback upon firing
+ *
+ * @return i2c_status_t Status code.
+ */
+i2c_error_t hal_i2c_mem_write(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                              uint8_t *data, uint16_t len, i2c_tx_callback_t cb,
+                              i2c_error_cb_t err_cb, void *ctx);
 
 /**
  * @brief Read data from an I2C device.
@@ -110,11 +147,15 @@ i2c_status_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
  * @param[in] addr    The 7-bit device address.
  * @param[out] data   Pointer to the buffer to store received data.
  * @param[in] len     Number of bytes to read.
+ * @param[in] cb      The callback to fire upon completion
+ * @param[in] err_cb  The callback to fire upon an error occurring
+ * @param[in] ctx     The context to provide to the callback upon firing
  *
  * @return i2c_status_t Status code.
  */
-i2c_status_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
-                          uint16_t len);
+i2c_error_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
+                         uint16_t len, i2c_rx_callback_t cb,
+                         i2c_error_cb_t err_cb, void *ctx);
 
 /**
  * @brief Write to a register, then read data (Common pattern for sensors).
@@ -124,11 +165,15 @@ i2c_status_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
  * @param[in] reg     The register address to read from.
  * @param[out] data   Pointer to the buffer to store received data.
  * @param[in] len     Number of bytes to read.
+ * @param[in] cb      The callback to fire upon completion
+ * @param[in] err_cb  The callback to fire upon an error occurring
+ * @param[in] ctx     The context to provide to the callback upon firing
  *
  * @return i2c_status_t Status code.
  */
-i2c_status_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
-                              uint8_t *data, uint16_t len);
+i2c_error_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                             uint8_t *data, uint16_t len, i2c_rx_callback_t cb,
+                             i2c_error_cb_t err_cb, void *ctx);
 
 /**
  * @brief ISR entry point for I2C interrupts

--- a/eps/firmware/hal/hal_uart.h
+++ b/eps/firmware/hal/hal_uart.h
@@ -47,7 +47,6 @@ typedef enum {
  * @enum uart_error_t
  * @brief Errors that could occur during UART HAL use
  */
-
 typedef enum {
     UART_HAL_ERR_OVERRUN,
     UART_HAL_ERR_NOISE,

--- a/eps/firmware/mocks/hal_i2c_mock.c
+++ b/eps/firmware/mocks/hal_i2c_mock.c
@@ -1,4 +1,5 @@
 #include "hal_i2c_mock.h"
+#include "hal_i2c.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -10,6 +11,8 @@ static uint16_t next_read_len = 0;
 static uint8_t last_write_buffer[MOCK_I2C_BUF_SIZE];
 static uint16_t last_write_len = 0;
 static uint8_t last_write_addr = 0;
+static uint8_t last_write_reg = 0;
+static bool last_write_was_mem = false;
 
 void mock_i2c_set_next_read_data(const uint8_t *data, uint16_t len) {
     if (len > MOCK_I2C_BUF_SIZE) {
@@ -17,14 +20,20 @@ void mock_i2c_set_next_read_data(const uint8_t *data, uint16_t len) {
     }
 
     memcpy(next_read_buffer, data, len);
-
     next_read_len = len;
 }
 
-uint16_t mock_i2c_get_last_write(uint8_t *addr_out, uint8_t *buffer,
+uint16_t mock_i2c_get_last_write(uint8_t *addr_out, uint8_t *reg_out,
+                                 bool *was_mem, uint8_t *buffer,
                                  uint16_t max_len) {
     if (addr_out) {
         *addr_out = last_write_addr;
+    }
+    if (reg_out) {
+        *reg_out = last_write_reg;
+    }
+    if (was_mem) {
+        *was_mem = last_write_was_mem;
     }
 
     uint16_t copy_len = (last_write_len < max_len) ? last_write_len : max_len;
@@ -32,48 +41,100 @@ uint16_t mock_i2c_get_last_write(uint8_t *addr_out, uint8_t *buffer,
     if (buffer && copy_len > 0) {
         memcpy(buffer, last_write_buffer, copy_len);
     }
+
     return last_write_len;
 }
 
-i2c_status_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
-                           uint16_t len) {
-    printf("[HITL] I2C WRITE | Bus: %d | Addr: 0x%02X | Len: %d\n", bus, addr,
-           len);
+void hal_i2c_init(i2c_bus_t bus) { (void)bus; }
 
-    // capture the write for test verification
+i2c_error_t hal_i2c_write(i2c_bus_t bus, uint8_t addr, const uint8_t *data,
+                          uint16_t len, i2c_tx_callback_t cb,
+                          i2c_error_cb_t err_cb, void *ctx) {
+    (void)bus;
+    (void)err_cb;
+
+    printf("[MOCK] I2C WRITE | Addr: 0x%02X | Len: %u\n", addr, len);
+
     last_write_addr = addr;
+    last_write_reg = 0;
+    last_write_was_mem = false;
     last_write_len = (len < MOCK_I2C_BUF_SIZE) ? len : MOCK_I2C_BUF_SIZE;
 
     memcpy(last_write_buffer, data, last_write_len);
 
-    return I2C_OK;
-}
-
-i2c_status_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
-                          uint16_t len) {
-    printf("[HITL] I2C READ  | Bus: %d | Addr: 0x%02X | Len: %d\n", bus, addr,
-           len);
-
-    if (next_read_len > 0) {
-        // return pre-loaded mock data
-        uint16_t copy_len = (len < next_read_len) ? len : next_read_len;
-        memcpy(data, next_read_buffer, copy_len);
-
-        return I2C_OK;
+    if (cb) {
+        cb(bus, ctx);
     }
 
-    // default: return 0s if nothing mocked
-    memset(data, 0, len);
-
-    return I2C_OK;
+    return I2C_HAL_ERR_NONE;
 }
 
-i2c_status_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
-                              uint8_t *data, uint16_t len) {
-    printf("[HITL] I2C MEM READ | Bus: %d | Addr: 0x%02X | Reg: 0x%02X\n", bus,
-           addr, reg);
+i2c_error_t hal_i2c_mem_write(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                              uint8_t *data, uint16_t len, i2c_tx_callback_t cb,
+                              i2c_error_cb_t err_cb, void *ctx) {
+    (void)bus;
+    (void)err_cb;
 
-    // for simplicity in simple mocks, redirect to standard read logic
-    // or implement specific register logic here.
-    return hal_i2c_read(bus, addr, data, len);
+    printf("[MOCK] I2C MEM WRITE | Addr: 0x%02X | Reg: 0x%02X | Len: %u\n",
+           addr, reg, len);
+
+    last_write_addr = addr;
+    last_write_reg = reg;
+    last_write_was_mem = true;
+    last_write_len = (len < MOCK_I2C_BUF_SIZE) ? len : MOCK_I2C_BUF_SIZE;
+
+    memcpy(last_write_buffer, data, last_write_len);
+
+    if (cb) {
+        cb(bus, ctx);
+    }
+
+    return I2C_HAL_ERR_NONE;
 }
+
+i2c_error_t hal_i2c_read(i2c_bus_t bus, uint8_t addr, uint8_t *data,
+                         uint16_t len, i2c_rx_callback_t cb,
+                         i2c_error_cb_t err_cb, void *ctx) {
+    (void)addr;
+    (void)err_cb;
+
+    printf("[MOCK] I2C READ | Len: %u\n", len);
+
+    if (next_read_len > 0) {
+        uint16_t copy_len = (len < next_read_len) ? len : next_read_len;
+        memcpy(data, next_read_buffer, copy_len);
+    } else {
+        memset(data, 0, len);
+    }
+
+    if (cb) {
+        cb(bus, ctx);
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+i2c_error_t hal_i2c_mem_read(i2c_bus_t bus, uint8_t addr, uint8_t reg,
+                             uint8_t *data, uint16_t len, i2c_rx_callback_t cb,
+                             i2c_error_cb_t err_cb, void *ctx) {
+    (void)addr;
+    (void)reg;
+    (void)err_cb;
+
+    printf("[MOCK] I2C MEM READ | Reg: 0x%02X | Len: %u\n", reg, len);
+
+    if (next_read_len > 0) {
+        uint16_t copy_len = (len < next_read_len) ? len : next_read_len;
+        memcpy(data, next_read_buffer, copy_len);
+    } else {
+        memset(data, 0, len);
+    }
+
+    if (cb) {
+        cb(bus, ctx);
+    }
+
+    return I2C_HAL_ERR_NONE;
+}
+
+void hal_i2c_isr_handler(i2c_bus_t bus) { (void)bus; }

--- a/eps/firmware/mocks/hal_i2c_mock.h
+++ b/eps/firmware/mocks/hal_i2c_mock.h
@@ -17,12 +17,15 @@ void mock_i2c_set_next_read_data(const uint8_t *data, uint16_t len);
  * @brief Gets the last data written to the mock bus via i2c_write().
  *
  * @param[out] addr_out  Pointer to store the address that was written to.
+ * @param[out] reg_out   Contents written to the lsat register
+ * @param[out] bool      Whether the last write wsa to peripheral memory
  * @param[out] buffer    Pointer to copy the written data into.
  * @param[in]  max_len   Max bytes to copy.
  *
  * @return uint16_t      Number of bytes actually written in the last op.
  */
-uint16_t mock_i2c_get_last_write(uint8_t *addr_out, uint8_t *buffer,
+uint16_t mock_i2c_get_last_write(uint8_t *addr_out, uint8_t *reg_out,
+                                 bool *was_mem, uint8_t *buffer,
                                  uint16_t max_len);
 
 #endif // HAL_I2C_MOCK_H


### PR DESCRIPTION
These changes introduce the following:

- A complete I2C HAL driver
  - The HAL driver is asynchronous--upon starting a read, the driver will start a read based on I2C interrupts. The consumer provides callbacks for both completion and error, and after returning from the ISR the driver will copy the read bytes into the data buffer and trigger the consumer's callback
  - Writes work similarly
  - The driver also exposes a hal_i2c_mem_* interface that allows register/memory selection prior to starting a read. This means that the consumer can select a register to read from by first writing to the device and then receive it. 
  - The consumer can also write directly to a peripheral's memory/register
  - The HAL also internally tracks the busy state of the line, so overlapping reads/writes are not an issue. But it is up to the consumer to retry if a conflict occurs.