### PR TITLE
Audit determinism with super loop structure & fix non-deterministic services

### DIFF
--- a/eps/firmware/bsp/mcu/Inc/main.h
+++ b/eps/firmware/bsp/mcu/Inc/main.h
@@ -41,7 +41,7 @@ extern "C" {
 
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
-
+extern volatile uint8_t g_main_tick_flag;
 /* USER CODE END EC */
 
 /* Exported macro ------------------------------------------------------------*/

--- a/eps/firmware/bsp/mcu/Src/stm32l4xx_it.c
+++ b/eps/firmware/bsp/mcu/Src/stm32l4xx_it.c
@@ -173,13 +173,20 @@ void PendSV_Handler(void) {
 /**
  * @brief This function handles System tick timer.
  */
+volatile uint8_t g_main_tick_flag = 0;
+static uint32_t tick_divider = 0;
+
 void SysTick_Handler(void) {
     /* USER CODE BEGIN SysTick_IRQn 0 */
 
     /* USER CODE END SysTick_IRQn 0 */
     HAL_IncTick();
     /* USER CODE BEGIN SysTick_IRQn 1 */
-
+    tick_divider++;
+    if (tick_divider >= 10) {
+        tick_divider = 0;
+        g_main_tick_flag = 1;
+    }
     /* USER CODE END SysTick_IRQn 1 */
 }
 

--- a/eps/firmware/hal/hal_time.c
+++ b/eps/firmware/hal/hal_time.c
@@ -16,5 +16,3 @@ uint64_t hal_time_get_us(void) {
     // approximate microseconds from millisecond tick
     return (uint64_t)HAL_GetTick() * 1000ULL;
 }
-
-void hal_time_delay_ms(uint32_t ms) { HAL_Delay(ms); }

--- a/eps/firmware/hal/hal_time.h
+++ b/eps/firmware/hal/hal_time.h
@@ -53,13 +53,6 @@ uint32_t hal_time_get_ms(void);
  */
 uint64_t hal_time_get_us(void);
 
-/**
- * @brief Blocking delay in milliseconds.
- *
- * @param[in] ms Number of milliseconds to delay.
- */
-void hal_time_delay_ms(uint32_t ms);
-
 /** @} */ // end hal_time_api
 
 /** @} */ // end hal_time

--- a/eps/firmware/hal/hal_uart.c
+++ b/eps/firmware/hal/hal_uart.c
@@ -15,6 +15,7 @@
 // size of the raw DMA buffer
 // ideally 2x the max expected packet size to prevent overwrites
 #define DMA_BUFFER_SIZE 256
+#define UART_TX_CAPACITY 512
 
 /**
  * @brief Internal UART port state
@@ -25,8 +26,13 @@ typedef struct {
     osusat_ring_buffer_t rx_ring;         /**< RX ring buffer */
     uint8_t rx_storage[UART_RX_CAPACITY]; /**< RX buffer storage */
 
+    osusat_ring_buffer_t tx_ring;         /**< TX ring buffer */
+    uint8_t tx_storage[UART_TX_CAPACITY]; /**< TX buffer storage */
+
     uint8_t dma_buffer[DMA_BUFFER_SIZE];
     uint32_t last_dma_pos; /**< Tracks where we last read from the DMA buffer */
+
+    uint8_t current_tx_byte; /**< Single byte buffer for HAL_UART_Transmit_IT */
 
     uart_rx_callback_t rx_callback; /**< User RX callback */
     void *rx_callback_ctx;          /**< User callback context */
@@ -43,6 +49,21 @@ extern UART_HandleTypeDef huart1;
 // extern UART_HandleTypeDef huart2;
 extern UART_HandleTypeDef huart3;
 // extern UART_HandleTypeDef huart4;
+
+/**
+ * @brief Helper to kick-start a TX if none is in progress.
+ */
+static void uart_start_tx(uart_port_t port) {
+    uart_port_state_t *state = &g_uart_state[port];
+
+    if (state->huart->gState != HAL_UART_STATE_READY) {
+        return;
+    }
+
+    if (osusat_ring_buffer_pop(&state->tx_ring, &state->current_tx_byte)) {
+        HAL_UART_Transmit_IT(state->huart, &state->current_tx_byte, 1);
+    }
+}
 
 /**
  * @brief Map uart_port_t to STM32 HAL handle
@@ -122,6 +143,8 @@ void hal_uart_init(uart_port_t port, const uart_config_t *config) {
 
     osusat_ring_buffer_init(&state->rx_ring, state->rx_storage,
                             UART_RX_CAPACITY, true);
+    osusat_ring_buffer_init(&state->tx_ring, state->tx_storage,
+                            UART_TX_CAPACITY, true);
 
     state->huart->Init.BaudRate = config->baudrate;
     state->huart->Init.WordLength = UART_WORDLENGTH_8B;
@@ -178,8 +201,14 @@ void hal_uart_write(uart_port_t port, const uint8_t *data, uint16_t len) {
         return;
     }
 
-    // NOTE: blocking
-    HAL_UART_Transmit(state->huart, (uint8_t *)data, len, HAL_MAX_DELAY);
+    // non-blocking push to tx_ring
+    for (uint16_t i = 0; i < len; i++) {
+        if (!osusat_ring_buffer_push(&state->tx_ring, data[i])) {
+            break; // buffer full
+        }
+    }
+
+    uart_start_tx(port);
 }
 
 uint16_t hal_uart_read(uart_port_t port, uint8_t *out, uint16_t len) {
@@ -250,11 +279,16 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
 }
 
 /**
- * @brief HAL callback for TX complete (optional)
+ * @brief HAL callback for TX complete
+ * This continues the TX chain if more data is in the tx_ring
  */
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
-    // could add TX complete callback here if needed
-    (void)huart;
+    for (int i = 0; i < UART_PORT_MAX; i++) {
+        if (g_uart_state[i].huart == huart) {
+            uart_start_tx(i);
+            return;
+        }
+    }
 }
 
 /**

--- a/eps/firmware/main.c
+++ b/eps/firmware/main.c
@@ -85,6 +85,7 @@ int main() {
 
     LOG_INFO(EPS_COMPONENT_MAIN, "Initialization complete");
 
+#if defined(__arm__)
     extern volatile uint8_t g_main_tick_flag;
 
     while (1) {
@@ -95,6 +96,11 @@ int main() {
             __WFI();
         }
     }
+#else
+    while (1) {
+        osusat_event_bus_process();
+    }
+#endif
 
     return 0;
 }

--- a/eps/firmware/main.c
+++ b/eps/firmware/main.c
@@ -85,8 +85,15 @@ int main() {
 
     LOG_INFO(EPS_COMPONENT_MAIN, "Initialization complete");
 
+    extern volatile uint8_t g_main_tick_flag;
+
     while (1) {
-        osusat_event_bus_process();
+        if (g_main_tick_flag) {
+            g_main_tick_flag = 0;
+            osusat_event_bus_process();
+        } else {
+            __WFI();
+        }
     }
 
     return 0;

--- a/eps/firmware/mocks/hal_time_mock.c
+++ b/eps/firmware/mocks/hal_time_mock.c
@@ -36,5 +36,3 @@ uint64_t hal_time_get_us(void) {
 
     return get_time_us() - g_start_time_us;
 }
-
-void hal_time_delay_ms(uint32_t ms) { usleep(ms * 1000); }


### PR DESCRIPTION
This PR is the result of an audit of the codebase for determinism using a super-loop + event-bus structure, not a RTOS. Previously, the main, event-dispatching loop was unbounded and tried to run as fast as possible, which could introduce jitter and make timing non-deterministic by processing actions based on CPU load. Instead, we now bound the main loop by a 100Hz tick, which dispatches a now limited number of events per tick.

Additionally, services were audited for blocking or non-deterministic behavior and changed accordingly. Most of them were fine but the UART events/logging service used a blocking transmission that made log flushes and other UART operations non-deterministic. Now, transmission is based on interrupts by transmitting one byte at a time.

Finally, the delay functions in the time HAL were removed since blocking is non-deterministic.